### PR TITLE
ci-hardening: Phase 6 – local act support

### DIFF
--- a/.actrc
+++ b/.actrc
@@ -1,0 +1,1 @@
+-P ubuntu-latest=ghcr.io/gmtfrombc/ci-base:latest --container-architecture linux/amd64 --secret-file .secrets 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,3 @@
+.PHONY: ci-local
+ci-local:
+	@bash scripts/run_ci_locally.sh $(ARGS) 

--- a/docs/0_0_Core_docs/ACT_CLI/README.md
+++ b/docs/0_0_Core_docs/ACT_CLI/README.md
@@ -4,24 +4,27 @@
 > repo uses without pushing a single commit.
 
 # Hardware: Macbook Air with M3 Apple chip
+
 # Supabase Secrets:located at: ~/.bee_secrets/supabase.env
 
 # NOTE: Run ACT from ROOT (BEE-MVP) with the following:
 
-bash scripts/run_ci_locally.sh -j deploy | cat  **NOTE: deploy only**
+bash scripts/run_ci_locally.sh -j deploy | cat **NOTE: deploy only**
 
-bash scripts/run_ci_locally.sh  **NOTE: build and deploy**
+bash scripts/run_ci_locally.sh **NOTE: build and deploy**
 
-bash SKIP_MIGRATIONS=true ./scripts/run_ci_locally.sh   **NOTE: skip migrations/deploy**
+bash SKIP_MIGRATIONS=true ./scripts/run_ci_locally.sh **NOTE: skip
+migrations/deploy**
 
-bash scripts/run_ci_locally.sh -q | tee ci.log  **NOTE: normal red/green run (quiet with failures)**
+bash scripts/run_ci_locally.sh -q | tee ci.log **NOTE: normal red/green run
+(quiet with failures)**
 
-bash grep -n --color ERROR ci.log | head  **NOTE: when something fails**
+bash grep -n --color ERROR ci.log | head **NOTE: when something fails**
 
-bash awk 'NR>=start-30 && NR<=start+30' start=$(grep -n "Supabase" -m1 ci.log | cut -d: -f1) ci.log  **NOTE: if I need more info aroudn a specific error**
+bash awk 'NR>=start-30 && NR<=start+30' start=$(grep -n "Supabase" -m1 ci.log |
+cut -d: -f1) ci.log **NOTE: if I need more info aroudn a specific error**
 
-bash scripts/run_ci_locally.sh --job flutter-ci --verbose | tee flutter.log  **NOTE: to run a specific 'job' e.g. flutter-ci etc.**
----
+## bash scripts/run_ci_locally.sh --job flutter-ci --verbose | tee flutter.log **NOTE: to run a specific 'job' e.g. flutter-ci etc.**
 
 ## 1. Prerequisites
 
@@ -67,7 +70,7 @@ Advanced: call `act` directly
 ```bash
 act push \
   -W .github/workflows/ci.yml \
-  -P ubuntu-latest=ghcr.io/catthehacker/ubuntu:act-22.04 \
+  -P ubuntu-latest=ghcr.io/gmtfrombc/ci-base:latest \
   --container-architecture linux/amd64 \
   --env ACT=false \
   --secret-file .secrets
@@ -183,3 +186,10 @@ SKIP_MIGRATIONS=true ./scripts/run_ci_locally.sh
 ---
 
 Happy **offline-CI**! 🎉
+
+### Quick shortcut
+
+```bash
+make ci-local           # full CI
+make ci-local ARGS="-j fast"  # just fast job
+```

--- a/docs/TODO_List/HOUSEKEEPING_CI_HARDENING/ci_hardening_checklist.md
+++ b/docs/TODO_List/HOUSEKEEPING_CI_HARDENING/ci_hardening_checklist.md
@@ -69,10 +69,10 @@
 
 ## ☑️ Phase 6 – Local Repro with `act`
 
-| #   | Task                                                                                          | Acceptance               | Status     |
-| --- | --------------------------------------------------------------------------------------------- | ------------------------ | ---------- |
-| 6.1 | Configure `act` to pull the same container: <br>`-P ubuntu-latest=ghcr.io/bee/ci-base:latest` | `act pull_request` green | 🟡 Planned |
-| 6.2 | Add `make ci-local` shortcut that runs `act` plus common flags                                | One-command local CI     | 🟡 Planned |
+| #   | Task                                                                                                | Acceptance               | Status      |
+| --- | --------------------------------------------------------------------------------------------------- | ------------------------ | ----------- |
+| 6.1 | Configure `act` to pull the same container: <br>`-P ubuntu-latest=ghcr.io/gmtfrombc/ci-base:latest` | `act pull_request` green | ✅ Complete |
+| 6.2 | Add `make ci-local` shortcut that runs `act` plus common flags                                      | One-command local CI     | ✅ Complete |
 
 ---
 

--- a/scripts/run_ci_locally.sh
+++ b/scripts/run_ci_locally.sh
@@ -228,7 +228,7 @@ fi
 #    requested job is the Flutter CI "test" job for dramatically faster runs.
 # -------------------------------------------------------------------------
 # Default minimal image for backend/integration workflows
-DEFAULT_RUNNER_IMAGE="ghcr.io/catthehacker/ubuntu:act-22.04"
+DEFAULT_RUNNER_IMAGE="ghcr.io/gmtfrombc/ci-base:latest"
 # Flutter-optimised image (contains SDK $FLUTTER_VERSION and Android toolchain)
 FLUTTER_RUNNER_IMAGE="ghcr.io/instrumentisto/flutter:${FLUTTER_VERSION}-androidsdk35-r0"
 


### PR DESCRIPTION
Implements Phase 6 of the CI Hardening checklist. Adds .actrc mapping, Makefile shortcut for ci-local, updates run_ci_locally.sh default image and documentation. Checklist items 6.1 and 6.2 marked complete.