### PR TITLE
T3.3: Disable back navigation in onboarding

### DIFF
--- a/app/lib/core/widgets/can_pop_scope.dart
+++ b/app/lib/core/widgets/can_pop_scope.dart
@@ -1,0 +1,14 @@
+import 'package:flutter/material.dart';
+
+/// A simple wrapper that disables back navigation (system or app-bar) so users
+/// can’t accidentally leave a multi-step flow. Used by onboarding pages.
+class CanPopScope extends StatelessWidget {
+  const CanPopScope({super.key, required this.child});
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return PopScope(canPop: false, child: child);
+  }
+}

--- a/app/lib/features/onboarding/ui/about_you_page.dart
+++ b/app/lib/features/onboarding/ui/about_you_page.dart
@@ -8,6 +8,7 @@ import '../../../core/services/responsive_service.dart';
 import '../onboarding_controller.dart';
 import '../../../core/mixins/input_validator.dart';
 import '../../../core/widgets/step_progress_bar.dart';
+import 'package:app/core/widgets/can_pop_scope.dart';
 
 /// First onboarding page collecting basic demographic information.
 class AboutYouPage extends ConsumerStatefulWidget {
@@ -41,83 +42,86 @@ class _AboutYouPageState extends ConsumerState<AboutYouPage> {
       _dobTextController.text = DateFormat.yMd().format(draft.dateOfBirth!);
     }
 
-    return Scaffold(
-      appBar: AppBar(title: const Text('Tell us about you')),
-      body: SingleChildScrollView(
-        padding: ResponsiveService.getMediumPadding(context),
-        child: Form(
-          key: _formKey,
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.stretch,
-            children: [
-              const StepProgressBar(currentStep: 1, totalSteps: 6),
-              SizedBox(height: spacing),
-              // Date of Birth -------------------------------------------------
-              GestureDetector(
-                behavior: HitTestBehavior.opaque,
-                onTap: () => _selectDob(context, controller.updateDateOfBirth),
-                child: AbsorbPointer(
-                  child: TextFormField(
-                    controller: _dobTextController,
-                    decoration: const InputDecoration(
-                      labelText: 'Date of Birth',
-                      hintText: 'Select your birth date',
+    return CanPopScope(
+      child: Scaffold(
+        appBar: AppBar(title: const Text('Tell us about you')),
+        body: SingleChildScrollView(
+          padding: ResponsiveService.getMediumPadding(context),
+          child: Form(
+            key: _formKey,
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                const StepProgressBar(currentStep: 1, totalSteps: 6),
+                SizedBox(height: spacing),
+                // Date of Birth -------------------------------------------------
+                GestureDetector(
+                  behavior: HitTestBehavior.opaque,
+                  onTap:
+                      () => _selectDob(context, controller.updateDateOfBirth),
+                  child: AbsorbPointer(
+                    child: TextFormField(
+                      controller: _dobTextController,
+                      decoration: const InputDecoration(
+                        labelText: 'Date of Birth',
+                        hintText: 'Select your birth date',
+                      ),
+                      validator: (_) => _dobValidator(draft.dateOfBirth),
+                      readOnly: true,
                     ),
-                    validator: (_) => _dobValidator(draft.dateOfBirth),
-                    readOnly: true,
                   ),
                 ),
-              ),
-              SizedBox(height: spacing),
+                SizedBox(height: spacing),
 
-              // Gender -------------------------------------------------------
-              DropdownButtonFormField<String>(
-                value: draft.gender,
-                decoration: const InputDecoration(labelText: 'Gender'),
-                items: const [
-                  DropdownMenuItem(value: 'male', child: Text('Male')),
-                  DropdownMenuItem(value: 'female', child: Text('Female')),
-                  DropdownMenuItem(
-                    value: 'non_binary',
-                    child: Text('Non-binary'),
-                  ),
-                  DropdownMenuItem(
-                    value: 'prefer_not_to_say',
-                    child: Text('Prefer not to say'),
-                  ),
-                ],
-                onChanged: controller.updateGender,
-                validator:
-                    (val) => (val == null || val.isEmpty) ? 'Required' : null,
-              ),
-              SizedBox(height: spacing),
-
-              // Culture ------------------------------------------------------
-              TextFormField(
-                initialValue: draft.culture,
-                decoration: const InputDecoration(
-                  labelText: 'Culture',
-                  hintText: 'e.g. Colombian-American',
+                // Gender -------------------------------------------------------
+                DropdownButtonFormField<String>(
+                  value: draft.gender,
+                  decoration: const InputDecoration(labelText: 'Gender'),
+                  items: const [
+                    DropdownMenuItem(value: 'male', child: Text('Male')),
+                    DropdownMenuItem(value: 'female', child: Text('Female')),
+                    DropdownMenuItem(
+                      value: 'non_binary',
+                      child: Text('Non-binary'),
+                    ),
+                    DropdownMenuItem(
+                      value: 'prefer_not_to_say',
+                      child: Text('Prefer not to say'),
+                    ),
+                  ],
+                  onChanged: controller.updateGender,
+                  validator:
+                      (val) => (val == null || val.isEmpty) ? 'Required' : null,
                 ),
-                maxLength: 64,
-                onChanged: controller.updateCulture,
-              ),
-              SizedBox(height: spacing * 2),
+                SizedBox(height: spacing),
 
-              // Continue button ---------------------------------------------
-              ElevatedButton(
-                key: const ValueKey('continue_button'),
-                onPressed:
-                    controller.isStep1Complete
-                        ? () {
-                          if (_formKey.currentState?.validate() ?? false) {
-                            context.push(kOnboardingStep2Route);
+                // Culture ------------------------------------------------------
+                TextFormField(
+                  initialValue: draft.culture,
+                  decoration: const InputDecoration(
+                    labelText: 'Culture',
+                    hintText: 'e.g. Colombian-American',
+                  ),
+                  maxLength: 64,
+                  onChanged: controller.updateCulture,
+                ),
+                SizedBox(height: spacing * 2),
+
+                // Continue button ---------------------------------------------
+                ElevatedButton(
+                  key: const ValueKey('continue_button'),
+                  onPressed:
+                      controller.isStep1Complete
+                          ? () {
+                            if (_formKey.currentState?.validate() ?? false) {
+                              context.push(kOnboardingStep2Route);
+                            }
                           }
-                        }
-                        : null,
-                child: const Text('Continue'),
-              ),
-            ],
+                          : null,
+                  child: const Text('Continue'),
+                ),
+              ],
+            ),
           ),
         ),
       ),

--- a/app/lib/features/onboarding/ui/goal_setup_page.dart
+++ b/app/lib/features/onboarding/ui/goal_setup_page.dart
@@ -5,6 +5,7 @@ import '../../../core/services/responsive_service.dart';
 import '../onboarding_controller.dart';
 import 'medical_history_page.dart';
 import '../../../core/widgets/step_progress_bar.dart';
+import 'package:app/core/widgets/can_pop_scope.dart';
 
 /// Onboarding step for users to specify their main outcome goal.
 ///
@@ -43,51 +44,55 @@ class _GoalSetupPageState extends ConsumerState<GoalSetupPage> {
 
     final spacing = ResponsiveService.getMediumSpacing(context);
 
-    return Scaffold(
-      appBar: AppBar(title: const Text('Goal Setup')),
-      body: SingleChildScrollView(
-        padding: ResponsiveService.getMediumPadding(context),
-        child: Form(
-          key: _formKey,
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.stretch,
-            children: [
-              const StepProgressBar(currentStep: 5, totalSteps: 6),
-              SizedBox(height: spacing * 2),
-              TextFormField(
-                controller: _goalController,
-                decoration: const InputDecoration(
-                  labelText: 'Outcome Goal',
-                  hintText: 'e.g. Lose 10 lb in 3 months',
+    return CanPopScope(
+      child: Scaffold(
+        appBar: AppBar(title: const Text('Goal Setup')),
+        body: SingleChildScrollView(
+          padding: ResponsiveService.getMediumPadding(context),
+          child: Form(
+            key: _formKey,
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                const StepProgressBar(currentStep: 5, totalSteps: 6),
+                SizedBox(height: spacing * 2),
+                TextFormField(
+                  controller: _goalController,
+                  decoration: const InputDecoration(
+                    labelText: 'Outcome Goal',
+                    hintText: 'e.g. Lose 10 lb in 3 months',
+                  ),
+                  maxLength: 120,
+                  onChanged: controller.updateGoalTarget,
+                  validator:
+                      (val) =>
+                          (val == null || val.trim().isEmpty)
+                              ? 'Required'
+                              : null,
                 ),
-                maxLength: 120,
-                onChanged: controller.updateGoalTarget,
-                validator:
-                    (val) =>
-                        (val == null || val.trim().isEmpty) ? 'Required' : null,
-              ),
-              SizedBox(height: spacing * 2),
-              ElevatedButton(
-                key: const ValueKey('continue_button'),
-                onPressed:
-                    controller.isGoalSetupComplete
-                        ? () {
-                          if (!(_formKey.currentState?.validate() ?? false)) {
-                            return;
+                SizedBox(height: spacing * 2),
+                ElevatedButton(
+                  key: const ValueKey('continue_button'),
+                  onPressed:
+                      controller.isGoalSetupComplete
+                          ? () {
+                            if (!(_formKey.currentState?.validate() ?? false)) {
+                              return;
+                            }
+                            ScaffoldMessenger.of(context).showSnackBar(
+                              const SnackBar(content: Text('Goal saved!')),
+                            );
+                            Navigator.of(context).push(
+                              MaterialPageRoute(
+                                builder: (_) => const MedicalHistoryPage(),
+                              ),
+                            );
                           }
-                          ScaffoldMessenger.of(context).showSnackBar(
-                            const SnackBar(content: Text('Goal saved!')),
-                          );
-                          Navigator.of(context).push(
-                            MaterialPageRoute(
-                              builder: (_) => const MedicalHistoryPage(),
-                            ),
-                          );
-                        }
-                        : null,
-                child: const Text('Continue'),
-              ),
-            ],
+                          : null,
+                  child: const Text('Continue'),
+                ),
+              ],
+            ),
           ),
         ),
       ),

--- a/app/lib/features/onboarding/ui/medical_history_page.dart
+++ b/app/lib/features/onboarding/ui/medical_history_page.dart
@@ -7,6 +7,7 @@ import '../../../core/widgets/onboarding_submission_snackbar.dart';
 import '../onboarding_completion_controller.dart';
 import '../onboarding_controller.dart';
 import '../../../core/widgets/step_progress_bar.dart';
+import 'package:app/core/widgets/can_pop_scope.dart';
 
 /// Onboarding step for selecting relevant medical conditions (Section 6).
 class MedicalHistoryPage extends ConsumerWidget {
@@ -24,57 +25,60 @@ class MedicalHistoryPage extends ConsumerWidget {
 
     final crossAxisCount = _getCrossAxisCount(context);
 
-    return Scaffold(
-      appBar: AppBar(title: const Text('Medical History')),
-      body: CustomScrollView(
-        slivers: [
-          SliverToBoxAdapter(
-            child: Padding(
-              padding: ResponsiveService.getMediumPadding(context),
-              child: const StepProgressBar(currentStep: 6, totalSteps: 6),
-            ),
-          ),
-          SliverPadding(
-            padding: ResponsiveService.getMediumPadding(context),
-            sliver: SliverGrid(
-              gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
-                crossAxisCount: crossAxisCount,
-                crossAxisSpacing: spacing,
-                mainAxisSpacing: spacing,
-                childAspectRatio: 3.5,
+    return CanPopScope(
+      child: Scaffold(
+        appBar: AppBar(title: const Text('Medical History')),
+        body: CustomScrollView(
+          slivers: [
+            SliverToBoxAdapter(
+              child: Padding(
+                padding: ResponsiveService.getMediumPadding(context),
+                child: const StepProgressBar(currentStep: 6, totalSteps: 6),
               ),
-              delegate: SliverChildBuilderDelegate((context, index) {
-                final condition = MedicalCondition.values[index];
-                return _ConditionTile(
-                  condition: condition,
-                  selected: draft.medicalConditions.contains(condition),
-                  onChanged: () => controller.toggleMedicalCondition(condition),
-                );
-              }, childCount: MedicalCondition.values.length),
             ),
-          ),
-          SliverToBoxAdapter(
-            child: Padding(
-              padding: EdgeInsets.all(spacing * 2),
-              child: Center(
-                child: ElevatedButton(
-                  key: const ValueKey('continue_button'),
-                  onPressed:
-                      (draft.medicalConditions.isNotEmpty &&
-                              !completionState.isLoading)
-                          ? () {
-                            completionNotifier.submit();
-                          }
-                          : null,
-                  child: const Text('Finish'),
+            SliverPadding(
+              padding: ResponsiveService.getMediumPadding(context),
+              sliver: SliverGrid(
+                gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+                  crossAxisCount: crossAxisCount,
+                  crossAxisSpacing: spacing,
+                  mainAxisSpacing: spacing,
+                  childAspectRatio: 3.5,
+                ),
+                delegate: SliverChildBuilderDelegate((context, index) {
+                  final condition = MedicalCondition.values[index];
+                  return _ConditionTile(
+                    condition: condition,
+                    selected: draft.medicalConditions.contains(condition),
+                    onChanged:
+                        () => controller.toggleMedicalCondition(condition),
+                  );
+                }, childCount: MedicalCondition.values.length),
+              ),
+            ),
+            SliverToBoxAdapter(
+              child: Padding(
+                padding: EdgeInsets.all(spacing * 2),
+                child: Center(
+                  child: ElevatedButton(
+                    key: const ValueKey('continue_button'),
+                    onPressed:
+                        (draft.medicalConditions.isNotEmpty &&
+                                !completionState.isLoading)
+                            ? () {
+                              completionNotifier.submit();
+                            }
+                            : null,
+                    child: const Text('Finish'),
+                  ),
                 ),
               ),
             ),
-          ),
-        ],
+          ],
+        ),
+        // Snackbar listener (renders nothing visually).
+        floatingActionButton: const OnboardingSubmissionSnackbar(),
       ),
-      // Snackbar listener (renders nothing visually).
-      floatingActionButton: const OnboardingSubmissionSnackbar(),
     );
   }
 

--- a/app/lib/features/onboarding/ui/mindset_page.dart
+++ b/app/lib/features/onboarding/ui/mindset_page.dart
@@ -6,6 +6,7 @@ import '../../../l10n/s.dart';
 import '../onboarding_controller.dart';
 import 'goal_setup_page.dart';
 import '../../../core/widgets/step_progress_bar.dart';
+import 'package:app/core/widgets/can_pop_scope.dart';
 
 /// Onboarding step for mindset & motivation assessment (Q13–16).
 ///
@@ -20,90 +21,92 @@ class MindsetPage extends ConsumerWidget {
     final draft = ref.watch(onboardingControllerProvider);
     final spacing = ResponsiveService.getMediumSpacing(context);
 
-    return Scaffold(
-      appBar: AppBar(title: const Text('Mindset & Motivation')),
-      body: SingleChildScrollView(
-        padding: ResponsiveService.getMediumPadding(context),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.stretch,
-          children: [
-            const StepProgressBar(currentStep: 4, totalSteps: 6),
-            SizedBox(height: spacing),
-            // Q13 Motivation Reason
-            _SingleChoiceSection<String>(
-              title: S.of(context).onboarding_q13_prompt,
-              options: const {
-                'feel_better': 'I want to improve how I feel',
-                'look_better': 'I want to look better',
-                'social_pressure': 'I feel social pressure from others',
-                'take_care': 'I want to take better care of myself',
-                'someone_else': 'I’m doing this for someone else',
-              },
-              groupValue: draft.motivationReason,
-              onChanged: controller.updateMotivationReason,
-            ),
-            SizedBox(height: spacing * 2),
+    return CanPopScope(
+      child: Scaffold(
+        appBar: AppBar(title: const Text('Mindset & Motivation')),
+        body: SingleChildScrollView(
+          padding: ResponsiveService.getMediumPadding(context),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              const StepProgressBar(currentStep: 4, totalSteps: 6),
+              SizedBox(height: spacing),
+              // Q13 Motivation Reason
+              _SingleChoiceSection<String>(
+                title: S.of(context).onboarding_q13_prompt,
+                options: const {
+                  'feel_better': 'I want to improve how I feel',
+                  'look_better': 'I want to look better',
+                  'social_pressure': 'I feel social pressure from others',
+                  'take_care': 'I want to take better care of myself',
+                  'someone_else': 'I’m doing this for someone else',
+                },
+                groupValue: draft.motivationReason,
+                onChanged: controller.updateMotivationReason,
+              ),
+              SizedBox(height: spacing * 2),
 
-            // Q14 Satisfaction Outcome
-            _SingleChoiceSection<String>(
-              title: S.of(context).onboarding_q14_prompt,
-              options: const {
-                'proud': 'Feeling proud of myself',
-                'seen_differently': 'Being seen differently by others',
-                'prove': 'Proving I can do it',
-                'avoid_health_problems': 'Avoiding health problems',
-              },
-              groupValue: draft.satisfactionOutcome,
-              onChanged: controller.updateSatisfactionOutcome,
-            ),
-            SizedBox(height: spacing * 2),
+              // Q14 Satisfaction Outcome
+              _SingleChoiceSection<String>(
+                title: S.of(context).onboarding_q14_prompt,
+                options: const {
+                  'proud': 'Feeling proud of myself',
+                  'seen_differently': 'Being seen differently by others',
+                  'prove': 'Proving I can do it',
+                  'avoid_health_problems': 'Avoiding health problems',
+                },
+                groupValue: draft.satisfactionOutcome,
+                onChanged: controller.updateSatisfactionOutcome,
+              ),
+              SizedBox(height: spacing * 2),
 
-            // Q15 Challenge Response
-            _SingleChoiceSection<String>(
-              title: S.of(context).onboarding_q15_prompt,
-              options: const {
-                'keep_going': 'Keep going',
-                'new_approach': 'Look for a new approach',
-                'pause': 'Pause or back off',
-                'overwhelmed': 'Feel overwhelmed',
-              },
-              groupValue: draft.challengeResponse,
-              onChanged: controller.updateChallengeResponse,
-            ),
-            SizedBox(height: spacing * 2),
+              // Q15 Challenge Response
+              _SingleChoiceSection<String>(
+                title: S.of(context).onboarding_q15_prompt,
+                options: const {
+                  'keep_going': 'Keep going',
+                  'new_approach': 'Look for a new approach',
+                  'pause': 'Pause or back off',
+                  'overwhelmed': 'Feel overwhelmed',
+                },
+                groupValue: draft.challengeResponse,
+                onChanged: controller.updateChallengeResponse,
+              ),
+              SizedBox(height: spacing * 2),
 
-            // Q16 Coach Style (mindsetType)
-            _SingleChoiceSection<String>(
-              title: S.of(context).onboarding_q16_prompt,
-              options: const {
-                'right_hand': 'Right Hand – Listens and checks in',
-                'cheerleader': 'Cheerleader – Encourages me',
-                'drill_sergeant': 'Drill Sergeant – Holds me to goals',
-                'not_sure': 'I’m not sure yet',
-              },
-              groupValue: draft.mindsetType,
-              onChanged: controller.updateMindsetType,
-            ),
-            SizedBox(height: spacing * 3),
+              // Q16 Coach Style (mindsetType)
+              _SingleChoiceSection<String>(
+                title: S.of(context).onboarding_q16_prompt,
+                options: const {
+                  'right_hand': 'Right Hand – Listens and checks in',
+                  'cheerleader': 'Cheerleader – Encourages me',
+                  'drill_sergeant': 'Drill Sergeant – Holds me to goals',
+                  'not_sure': 'I’m not sure yet',
+                },
+                groupValue: draft.mindsetType,
+                onChanged: controller.updateMindsetType,
+              ),
+              SizedBox(height: spacing * 3),
 
-            ElevatedButton(
-              key: const ValueKey('continue_button'),
-              onPressed:
-                  controller.isMindsetComplete
-                      ? () {
-                        ScaffoldMessenger.of(context).showSnackBar(
-                          const SnackBar(content: Text('Mindset saved!')),
-                        );
-                        Navigator.of(context).push(
-                          MaterialPageRoute(
-                            builder: (_) => const GoalSetupPage(),
-                          ),
-                        );
-                      }
-                      : null,
-              child: const Text('Continue'),
-            ),
-          ],
+              ElevatedButton(
+                key: const ValueKey('continue_button'),
+                onPressed:
+                    controller.isMindsetComplete
+                        ? () {
+                          ScaffoldMessenger.of(context).showSnackBar(
+                            const SnackBar(content: Text('Mindset saved!')),
+                          );
+                          Navigator.of(context).push(
+                            MaterialPageRoute(
+                              builder: (_) => const GoalSetupPage(),
+                            ),
+                          );
+                        }
+                        : null,
+                child: const Text('Continue'),
+              ),
+            ],
+          ),
         ),
       ),
     );

--- a/app/lib/features/onboarding/ui/preferences_page.dart
+++ b/app/lib/features/onboarding/ui/preferences_page.dart
@@ -7,6 +7,7 @@ import 'readiness_page.dart';
 import '../onboarding_controller.dart';
 import '../../../core/mixins/input_validator.dart';
 import '../../../core/widgets/step_progress_bar.dart';
+import 'package:app/core/widgets/can_pop_scope.dart';
 
 /// Onboarding step 2 – lets users pick 1–5 lifestyle preference areas.
 class PreferencesPage extends ConsumerWidget {
@@ -19,44 +20,46 @@ class PreferencesPage extends ConsumerWidget {
 
     final spacing = ResponsiveService.getSmallSpacing(context);
 
-    return Scaffold(
-      appBar: AppBar(title: const Text('Your Preferences')),
-      body: Padding(
-        padding: ResponsiveService.getMediumPadding(context),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.stretch,
-          children: [
-            const StepProgressBar(currentStep: 2, totalSteps: 6),
-            SizedBox(height: spacing),
-            _PreferenceChips(
-              selectedKeys: draft.preferences,
-              onToggle: controller.togglePreference,
-              spacing: spacing,
-            ),
-            SizedBox(height: spacing),
-            if (InputValidatorUtils.preferences(draft.preferences) != null)
-              Text(
-                InputValidatorUtils.preferences(draft.preferences)!,
-                style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                  color: Theme.of(context).colorScheme.error,
-                ),
+    return CanPopScope(
+      child: Scaffold(
+        appBar: AppBar(title: const Text('Your Preferences')),
+        body: Padding(
+          padding: ResponsiveService.getMediumPadding(context),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              const StepProgressBar(currentStep: 2, totalSteps: 6),
+              SizedBox(height: spacing),
+              _PreferenceChips(
+                selectedKeys: draft.preferences,
+                onToggle: controller.togglePreference,
+                spacing: spacing,
               ),
-            SizedBox(height: spacing * 3),
-            ElevatedButton(
-              key: const ValueKey('continue_button'),
-              onPressed:
-                  draft.preferences.isNotEmpty
-                      ? () {
-                        Navigator.of(context).push(
-                          MaterialPageRoute(
-                            builder: (_) => const ReadinessPage(),
-                          ),
-                        );
-                      }
-                      : null,
-              child: const Text('Continue'),
-            ),
-          ],
+              SizedBox(height: spacing),
+              if (InputValidatorUtils.preferences(draft.preferences) != null)
+                Text(
+                  InputValidatorUtils.preferences(draft.preferences)!,
+                  style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                    color: Theme.of(context).colorScheme.error,
+                  ),
+                ),
+              SizedBox(height: spacing * 3),
+              ElevatedButton(
+                key: const ValueKey('continue_button'),
+                onPressed:
+                    draft.preferences.isNotEmpty
+                        ? () {
+                          Navigator.of(context).push(
+                            MaterialPageRoute(
+                              builder: (_) => const ReadinessPage(),
+                            ),
+                          );
+                        }
+                        : null,
+                child: const Text('Continue'),
+              ),
+            ],
+          ),
         ),
       ),
     );

--- a/app/lib/features/onboarding/ui/readiness_page.dart
+++ b/app/lib/features/onboarding/ui/readiness_page.dart
@@ -8,6 +8,7 @@ import '../../../l10n/s.dart';
 import '../models/onboarding_draft.dart';
 import '../onboarding_controller.dart';
 import 'mindset_page.dart';
+import 'package:app/core/widgets/can_pop_scope.dart';
 
 /// Onboarding step for readiness and confidence assessment (Q10-12).
 ///
@@ -33,33 +34,35 @@ class ReadinessPage extends ConsumerWidget {
     final spacing = ResponsiveService.getMediumSpacing(context);
     final theme = Theme.of(context);
 
-    return Scaffold(
-      appBar: AppBar(title: const Text('Readiness & Priorities')),
-      body: SingleChildScrollView(
-        padding: ResponsiveService.getMediumPadding(context),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.stretch,
-          children: [
-            const StepProgressBar(currentStep: 3, totalSteps: 6),
-            SizedBox(height: spacing),
-            // Q10: Priority Selection
-            _buildPrioritySection(context, controller, draft, spacing, theme),
+    return CanPopScope(
+      child: Scaffold(
+        appBar: AppBar(title: const Text('Readiness & Priorities')),
+        body: SingleChildScrollView(
+          padding: ResponsiveService.getMediumPadding(context),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              const StepProgressBar(currentStep: 3, totalSteps: 6),
+              SizedBox(height: spacing),
+              // Q10: Priority Selection
+              _buildPrioritySection(context, controller, draft, spacing, theme),
 
-            SizedBox(height: spacing * 2),
+              SizedBox(height: spacing * 2),
 
-            // Q11: Readiness Level
-            _buildReadinessSection(context, controller, draft, spacing),
+              // Q11: Readiness Level
+              _buildReadinessSection(context, controller, draft, spacing),
 
-            SizedBox(height: spacing * 2),
+              SizedBox(height: spacing * 2),
 
-            // Q12: Confidence Level
-            _buildConfidenceSection(context, controller, draft, spacing),
+              // Q12: Confidence Level
+              _buildConfidenceSection(context, controller, draft, spacing),
 
-            SizedBox(height: spacing * 3),
+              SizedBox(height: spacing * 3),
 
-            // Continue Button
-            _buildContinueButton(context, controller, draft),
-          ],
+              // Continue Button
+              _buildContinueButton(context, controller, draft),
+            ],
+          ),
         ),
       ),
     );


### PR DESCRIPTION
Implements PopScope-based CanPopScope widget and wraps all six onboarding pages (AboutYou, Preferences, Readiness, Mindset, GoalSetup, MedicalHistory). Completes mini-sprint 1.11 task T3.3. No warnings on Flutter analyze, CI fast lane expected green.