### PR TITLE
feat(migrations): rate_limiting table & docs (M1.5.3 pre-milestone)

### DIFF
--- a/docs/MVP_ROADMAP/1-5 Action Steps Implementation/Milestones, Tasks, and Epic Docs/M1.5.3_ai_coach.md
+++ b/docs/MVP_ROADMAP/1-5 Action Steps Implementation/Milestones, Tasks, and Epic Docs/M1.5.3_ai_coach.md
@@ -1,0 +1,26 @@
+Use `rate_limiting` table (pattern from `momentum-score-calculator`) keyed by
+`user_id`, `function_name` with PG upsert in a Postgres RPC to ensure atomicity.
+
+```sql
+-- Rate Limiting infrastructure (added in M1.5.3 pre-milestone)
+CREATE TABLE IF NOT EXISTS rate_limiting (
+    user_id UUID NOT NULL,
+    function_name TEXT NOT NULL,
+    window_start TIMESTAMPTZ NOT NULL,
+    request_count INT NOT NULL DEFAULT 0,
+    last_request_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (user_id, function_name, window_start)
+);
+ALTER TABLE rate_limiting ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "Users can view own rate limits"
+    ON rate_limiting
+    FOR SELECT
+    USING (auth.uid() = user_id);
+CREATE POLICY "Service role can manage rate limits"
+    ON rate_limiting
+    FOR ALL
+    TO service_role
+    USING (true);
+CREATE INDEX idx_rate_limiting_func_window
+    ON rate_limiting(function_name, window_start DESC);
+```

--- a/docs/MVP_ROADMAP/1-5 Action Steps Implementation/Milestones, Tasks, and Epic Docs/pre-milestone mini sprint/M1.5.3_pre_milestone_audit.md
+++ b/docs/MVP_ROADMAP/1-5 Action Steps Implementation/Milestones, Tasks, and Epic Docs/pre-milestone mini sprint/M1.5.3_pre_milestone_audit.md
@@ -1,0 +1,61 @@
+### Pre-Milestone Readiness Audit — M1.5.3 AI Coach Suggestion Engine
+
+**Summary judgment:** ✅ Proceed (minor clarifications required)
+
+---
+
+#### 1. Missing or Ambiguous Items
+
+1. **Rate-Limiting Table Schema** – Spec references a `rate_limiting` table
+   patterned after _momentum-score-calculator_ but does not define columns or
+   migration path.
+2. **Error Contract Beyond 429** – Needs explicit JSON shape for validation
+   (4xx) vs. server (5xx) errors to keep front-end handling consistent.
+3. **Logging Strategy** – States “hash `user_id` when logging errors” but does
+   not specify log destination (Supabase logs vs. external APM).
+4. **Deployment Pipeline Step** – Spec says PR merges _trigger_ deploy; CI job
+   name & required secrets are not documented.
+5. **Seed Data for Local Testing** – No guidance on seeding `action_steps` or
+   `user_profile` rows when running tests locally/CI.
+6. **OpenAPI Doc Location** – Mentions
+   `docs/api/suggest_action_steps_openapi.yaml`; file not yet created in repo.
+
+#### 2. Non-Obvious Edge Cases to Cover
+
+- **User With No Prior Goals** – Ensure algorithm returns _new_ suggestions when
+  history length = 0.
+- **All Recent Goals Failed** – Should avoid recommending categories the user
+  consistently skipped.
+- **Large Priority List (> 10 items)** – Validate performance and result
+  relevance.
+- **High Frequency Constraint** – Reject or adjust if heuristic selects
+  frequency <3 or >7.
+- **Rate-Limit Race Condition** – Parallel calls from multiple devices within
+  the same second.
+- **DB Timeout / Network Glitch** – Verify graceful 5xx with retry-after header.
+
+#### 3. Mini QA Plan
+
+| Test Type       | Scope                                                                                                | Tooling                                     |
+| --------------- | ---------------------------------------------------------------------------------------------------- | ------------------------------------------- |
+| **Unit**        | Suggestion algorithm weighting, positive framing validator, frequency range guard, rate-limit helper | `deno test`, stubbing Supabase client       |
+| **Contract**    | Validate HTTP 200, 4xx (validation), 429 (rate-limit), 5xx paths with JSON schema                    | `supabe functions invoke` in CI job         |
+| **Integration** | End-to-end with local Postgres and populated sample data; assert latency <500 ms p95                 | `edge_function_testing_strategy.md` harness |
+| **Load/Perf**   | 100 rps warm calls to confirm latency target and rate-limit headers                                  | `k6` script in `supabase/tests/perf/`       |
+| **Security**    | Ensure JWT required when `--verify-jwt` re-enabled; check no PHI in logs                             | Static analysis + runtime inspection        |
+
+#### 4. Action Items Before Implementation
+
+| Task | Description                                                                                             | Status      |
+| ---- | ------------------------------------------------------------------------------------------------------- | ----------- |
+| 1    | Draft and migrate `rate_limiting` table schema; update spec with DDL                                    | ✅ Complete |
+| 2    | Add explicit error-response examples for 400 & 500 codes                                                | ⚪ Planned  |
+| 3    | Document logging destination & masking strategy in _Implementation Details_                             | ⚪ Planned  |
+| 4    | Define CI deploy step name (`deploy_suggest_action_steps`) and required ENV within `.github/workflows/` | ⚪ Planned  |
+| 5    | Provide SQL/JSON seed fixtures for local & CI test harness                                              | ⚪ Planned  |
+| 6    | Stub `docs/api/suggest_action_steps_openapi.yaml` with initial paths & schemas                          | ⚪ Planned  |
+| 7    | Confirm table/index permissions for cold-start <750 ms (consider `select()` column whitelist)           | ⚪ Planned  |
+
+---
+
+> _Prepared by AI Senior Developer audit bot on July 15, 2025

--- a/supabase/migrations/20250716010000_rate_limiting_table.sql
+++ b/supabase/migrations/20250716010000_rate_limiting_table.sql
@@ -1,0 +1,34 @@
+-- =====================================================
+-- Rate Limiting table for Edge Functions and other API call quotas
+-- =====================================================
+
+CREATE TABLE IF NOT EXISTS public.rate_limiting (
+    user_id UUID NOT NULL,
+    function_name TEXT NOT NULL,
+    window_start TIMESTAMPTZ NOT NULL,
+    request_count INTEGER NOT NULL DEFAULT 0,
+    last_request_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT rate_limiting_pkey PRIMARY KEY (user_id, function_name, window_start)
+);
+
+-- Indexes to speed up lookup by function name within a window
+CREATE INDEX IF NOT EXISTS idx_rate_limiting_func_window
+    ON public.rate_limiting(function_name, window_start DESC);
+
+-- Enable Row Level Security
+ALTER TABLE public.rate_limiting ENABLE ROW LEVEL SECURITY;
+
+-- Policy: users can view their own rate-limit records
+DROP POLICY IF EXISTS "Users can view own rate limits" ON public.rate_limiting;
+CREATE POLICY "Users can view own rate limits"
+    ON public.rate_limiting
+    FOR SELECT
+    USING (auth.uid() = user_id);
+
+-- Policy: service role has full access (supplied to edge functions)
+DROP POLICY IF EXISTS "Service role can manage rate limits" ON public.rate_limiting;
+CREATE POLICY "Service role can manage rate limits"
+    ON public.rate_limiting
+    FOR ALL
+    TO service_role
+    USING (true); 


### PR DESCRIPTION
Adds the rate_limiting table migration with RLS policies and updates relevant spec/docs per pre-milestone audit. All fast tests pass.