### PR TITLE
feat(edge-function): add unit tests for suggest-action-steps (T3)

### DIFF
--- a/docs/MVP_ROADMAP/1-5 Action Steps Implementation/Milestones, Tasks, and Epic Docs/M1.5.3_ai_coach.md
+++ b/docs/MVP_ROADMAP/1-5 Action Steps Implementation/Milestones, Tasks, and Epic Docs/M1.5.3_ai_coach.md
@@ -24,7 +24,7 @@ rate limits and privacy.
 | ------- | ------------------------------------------------------------------------------- | -------- | ----------- |
 | T1      | Create edge function `suggest-action-steps@1.0.0` (SemVer tag)                  | 4h       | ✅ Complete |
 | T2      | Implement logic: fetch past goals, user priorities, return 3-5 suggestions JSON | 4h       | ✅ Complete |
-| T3      | Add unit tests (`supabase/functions/tests/suggest_action_steps_test.ts`)        | 3h       | 🟡 Planned  |
+| T3      | Add unit tests (`supabase/functions/tests/suggest_action_steps_test.ts`)        | 3h       | ✅ Complete |
 | T4      | Wire function into AI Coach conversation engine                                 | 3h       | 🟡 Planned  |
 
 ## 📦 Milestone Deliverables

--- a/supabase/functions/tests/suggest-action-steps-algorithm.test.ts
+++ b/supabase/functions/tests/suggest-action-steps-algorithm.test.ts
@@ -1,0 +1,71 @@
+import { assertEquals } from "https://deno.land/std@0.208.0/assert/mod.ts";
+import {
+  CompletionLog,
+  computeSuggestions,
+  handler,
+  PlannedStep,
+} from "../suggest-action-steps/index.ts";
+
+Deno.test("computeSuggestions returns 3–5 ranked suggestions", () => {
+  const steps: PlannedStep[] = [
+    {
+      id: "s1",
+      category: "sleep",
+      frequency: 7,
+      week_start: "2025-07-14",
+    },
+    {
+      id: "s2",
+      category: "hydration",
+      frequency: 7,
+      week_start: "2025-07-14",
+    },
+    {
+      id: "s3",
+      category: "mobility",
+      frequency: 7,
+      week_start: "2025-07-14",
+    },
+    {
+      id: "s4",
+      category: "mindfulness",
+      frequency: 7,
+      week_start: "2025-07-14",
+    },
+  ];
+
+  // No completion logs – all categories under-performing
+  const suggestions = computeSuggestions(steps, [] as CompletionLog[]);
+  assertEquals(Array.isArray(suggestions), true);
+  // Should cap at 5 and have at least 3
+  assertEquals(suggestions.length >= 3 && suggestions.length <= 5, true);
+  // All required fields present
+  const first = suggestions[0]!;
+  assertEquals(typeof first.id, "string");
+  assertEquals(typeof first.title, "string");
+  assertEquals(typeof first.category, "string");
+  assertEquals(typeof first.description, "string");
+});
+
+Deno.test("handler enforces hourly rate-limit and returns 429 on repeat call", async () => {
+  const userId = "00000000-0000-0000-0000-00000000rate";
+  const reqInit = {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ user_id: userId }),
+  } as const;
+
+  const req1 = new Request("http://localhost/", reqInit);
+  const res1 = await handler(req1);
+  assertEquals(res1.status, 200);
+
+  // Immediate second request with the same user should hit the in-memory limiter
+  const req2 = new Request("http://localhost/", reqInit);
+  const res2 = await handler(req2);
+  assertEquals(res2.status, 429);
+
+  const body = await res2.json();
+  assertEquals(body.code, "RATE_LIMITED");
+  // Retry-After header should be present
+  assertEquals(res2.headers.has("Retry-After"), true);
+});


### PR DESCRIPTION
This PR completes Milestone M1.5.3 Task T3.\n\nKey updates:\n1. Extracted pure computeSuggestions() helper from edge function for easier testing.\n2. Added suggest-action-steps-algorithm.test.ts covering algorithm logic and rate-limit path.\n3. All Deno, Flutter, and Python fast tests pass locally (make ci-fast).\n4. Updated roadmap doc to mark T3 ✅ Complete.\n\nReady for review 🚀