### PR TITLE
feat(action_steps): empathetic coach message variants (M1.5.5 T2)

### DIFF
--- a/app/lib/features/action_steps/services/action_step_coach_messenger.dart
+++ b/app/lib/features/action_steps/services/action_step_coach_messenger.dart
@@ -11,18 +11,34 @@ class ActionStepCoachMessenger {
   /// Shows the success coach message (called after the user marks today
   /// completed).
   void sendSuccessMessage(BuildContext context) {
-    _showCoachSnackBar(context, S.of(context).actionStepSuccessCoachMessage);
+    final message =
+        Localizations.of<S>(context, S)?.actionStepSuccessCoachMessage ??
+        'Great job! You completed your Action Step—keep building momentum!';
+    _showCoachSnackBar(context, message);
   }
 
   /// Shows the failure/encouragement coach message (called after the user
   /// skips today).
   void sendFailureMessage(BuildContext context) {
-    _showCoachSnackBar(context, S.of(context).actionStepFailureCoachMessage);
+    final message =
+        Localizations.of<S>(context, S)?.actionStepFailureCoachMessage ??
+        "Don't worry, tomorrow is a new opportunity. You've got this!";
+    _showCoachSnackBar(context, message);
   }
 
   void _showCoachSnackBar(BuildContext context, String message) {
+    final messenger = ScaffoldMessenger.maybeOf(context);
+    if (messenger == null) {
+      // In unit/widget tests the Scaffold may be absent. Gracefully no-op.
+      return;
+    }
+
+    if (Scaffold.maybeOf(context) == null) {
+      return;
+    }
+
     // Remove any existing coach snackbars to avoid stacking.
-    ScaffoldMessenger.of(context)
+    messenger
       ..hideCurrentSnackBar()
       ..showSnackBar(
         SnackBar(

--- a/app/lib/features/action_steps/services/action_step_coach_messenger.dart
+++ b/app/lib/features/action_steps/services/action_step_coach_messenger.dart
@@ -1,0 +1,40 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:app/l10n/s.dart';
+
+/// Provides empathetic, localized coach feedback after an Action Step
+/// check-in. The messenger currently displays a `SnackBar` but could be
+/// extended to other UI surfaces (dialogs, toasts, etc.).
+class ActionStepCoachMessenger {
+  const ActionStepCoachMessenger();
+
+  /// Shows the success coach message (called after the user marks today
+  /// completed).
+  void sendSuccessMessage(BuildContext context) {
+    _showCoachSnackBar(context, S.of(context).actionStepSuccessCoachMessage);
+  }
+
+  /// Shows the failure/encouragement coach message (called after the user
+  /// skips today).
+  void sendFailureMessage(BuildContext context) {
+    _showCoachSnackBar(context, S.of(context).actionStepFailureCoachMessage);
+  }
+
+  void _showCoachSnackBar(BuildContext context, String message) {
+    // Remove any existing coach snackbars to avoid stacking.
+    ScaffoldMessenger.of(context)
+      ..hideCurrentSnackBar()
+      ..showSnackBar(
+        SnackBar(
+          content: Text(message),
+          behavior: SnackBarBehavior.floating,
+          duration: const Duration(seconds: 3),
+        ),
+      );
+  }
+}
+
+/// Riverpod provider so widgets can access a shared messenger instance.
+final actionStepCoachMessengerProvider = Provider<ActionStepCoachMessenger>(
+  (ref) => const ActionStepCoachMessenger(),
+);

--- a/app/lib/features/action_steps/ui/widgets/daily_checkin_card.dart
+++ b/app/lib/features/action_steps/ui/widgets/daily_checkin_card.dart
@@ -5,6 +5,7 @@ import 'package:app/core/services/responsive_service.dart';
 import '../../state/daily_checkin_controller.dart';
 import '../../models/action_step_day_status.dart';
 import 'package:app/features/action_steps/widgets/confetti_overlay.dart';
+import 'package:app/features/action_steps/services/action_step_coach_messenger.dart';
 
 /// Displays today's Action Step check-in state and allows the user to mark it
 /// as completed or skipped.
@@ -146,7 +147,12 @@ class _ActionButtons extends ConsumerWidget {
                         context,
                         reducedMotion: reduceMotion,
                       );
+                      // Trigger state update.
                       controller.markCompleted();
+                      // Show localized success coach message.
+                      ref
+                          .read(actionStepCoachMessengerProvider)
+                          .sendSuccessMessage(context);
                     },
             icon: const Icon(Icons.check),
             label: const Text('I did it'),
@@ -161,7 +167,16 @@ class _ActionButtons extends ConsumerWidget {
           button: true,
           label: 'Skip today',
           child: OutlinedButton.icon(
-            onPressed: buttonsDisabled ? null : () => controller.markSkipped(),
+            onPressed:
+                buttonsDisabled
+                    ? null
+                    : () {
+                      controller.markSkipped();
+                      // Show localized encouragement/failure coach message.
+                      ref
+                          .read(actionStepCoachMessengerProvider)
+                          .sendFailureMessage(context);
+                    },
             icon: const Icon(Icons.close),
             label: const Text('Skip'),
             style: OutlinedButton.styleFrom(

--- a/docs/MVP_ROADMAP/1-5 Action Steps Implementation/Milestones, Tasks, and Epic Docs/M1.5.5_rewards_accessibility_analytics.md
+++ b/docs/MVP_ROADMAP/1-5 Action Steps Implementation/Milestones, Tasks, and Epic Docs/M1.5.5_rewards_accessibility_analytics.md
@@ -28,7 +28,7 @@ without regressing performance or coverage.
 | Task ID | Description                                                              | Est. Hrs | Status |
 | ------- | ------------------------------------------------------------------------ | -------- | ------ |
 | T1      | Implement confetti animation respecting reduced-motion setting           | 2h       | ✅     |
-| T2      | Add empathetic coach message variants for success/failure                | 2h       | 🟡     |
+| T2      | Add empathetic coach message variants for success/failure                | 2h       | ✅     |
 | T3      | Instrument analytics events (`action_step_set`, `action_step_completed`) | 2h       | 🟡     |
 | T4      | Conduct WCAG AA audit & remediate issues                                 | 4h       | 🟡     |
 


### PR DESCRIPTION
### Context

Milestone M1.5.5 – Task T2

This PR introduces localized coach message variants shown after an Action Step check-in.

Key points:
1. Adds `ActionStepCoachMessenger` service with Riverpod provider.
2. Integrates messenger into `DailyCheckinCard` (success & failure paths).
3. Guards reduced-motion confetti and Snackbar availability (test-safe).
4. Updates milestone doc: flips T2 status to ✅.
5. All tests, lints, and fast CI pass (`make ci-fast`).