### PR TITLE
Health Data Docs & CI Completion (HD8-HD11)

### DIFF
--- a/app/lib/core/health_data/README.md
+++ b/app/lib/core/health_data/README.md
@@ -1,0 +1,45 @@
+# Health Data Module
+
+The **Health Data** module provides a single source of truth for all
+health-signal data – from perceived energy to manual biometrics – across the Bee
+mobile application.
+
+## Directory map
+
+```
+app/lib/core/health_data/
+  models/            ← Data classes (EnergyLevel, BiometricManualInput, MetabolicScore)
+  validators/        ← Numeric & unit validators shared by features
+  services/          ← HealthDataRepository + Riverpod provider
+  widgets/           ← UI components (EnergyInputSlider, BiometricsForm, etc.)
+```
+
+## Extending the module
+
+1. **Add/modify a model** in `models/`, ensuring `freezed` + `json_serializable`
+   are used where appropriate.
+2. **Expose CRUD methods** in `HealthDataRepository` (or a sub-repository) –
+   keep queries in the repository layer; UI must never talk to Supabase
+   directly.
+3. **Add validators** to `validators/` when logic will be reused across
+   features.
+4. **Create widgets** in `widgets/` that read from Riverpod providers and remain
+   stateless.
+
+> 💡 Keep each file < 300 LOC to avoid "God" files (see component governance
+> docs).
+
+## Supabase & RLS
+
+Schema lives in `supabase/migrations/V20250717_health_data.sql` and is protected
+by Row Level Security. All queries must include the authenticated user ID
+(`auth.uid()`). Repository tests mock Supabase to validate policy compliance.
+
+## Testing & coverage
+
+- Target ≥ 90 % line coverage for services/validators and ≥ 70 % for widgets
+  (golden tests counted).
+- Widget tests run in CI via `flutter test` – no extra configuration is
+  required.
+
+_Last updated: 2025-07-18_

--- a/app/lib/core/health_data/widgets/README.md
+++ b/app/lib/core/health_data/widgets/README.md
@@ -1,3 +1,34 @@
 # Health Data Widgets
 
-Placeholder for upcoming UI components such as EnergyInputSlider.
+This folder houses UI components that capture or visualise health-related user
+data.
+
+## Planned widgets
+
+- **EnergyInputSlider** – five-point scale slider for perceived energy level.
+- **BiometricsForm** – manual entry panel for weight, body-fat %, resting
+  heart-rate, etc.
+- **MetabolicScoreCard** – displays a composite metabolic score with trend
+  arrows.
+- **HealthSignalTrendChart** – sparkline able to plot any numeric signal.
+
+## Styling contract
+
+- Never hard-code colours or sizes – obtain them from `Theme.of(context)` and
+  `responsive_services.dart`.
+- Widgets must be fully responsive from 320 px widths up to tablet form-factors.
+- Follow Material accessibility recommendations; label all interactive elements
+  and use high-contrast focus styles.
+
+## Data flow
+
+Widgets are stateless and obtain data through Riverpod providers such as
+`healthDataRepositoryProvider`. Repository mocks **must** be used in widget
+tests to avoid network calls.
+
+## Testing & accessibility
+
+- Provide widget tests with golden images for visual regressions.
+- Use `mocktail` to stub repository calls and ensure predictable states.
+- Aim for ≥ 90 % statement coverage and include at least one a11y test using
+  `flutter_test`ʼs `SemanticsTester`.

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -771,7 +771,7 @@ packages:
     source: hosted
     version: "0.11.1"
   meta:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: meta
       sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c

--- a/docs/0_0_Core_docs/Refactor_projects/health_data_module_foundation_sprint.md
+++ b/docs/0_0_Core_docs/Refactor_projects/health_data_module_foundation_sprint.md
@@ -50,10 +50,10 @@
 | HD5  | Implement `services/health_data_repository.dart` with Riverpod provider                                       | new                       | mobile    | 2        | ✅ Complete | HD2-HD4 |
 | HD6  | Supabase migration file + RLS for both tables                                                                 | `supabase/migrations/`    | backend   | 2        | ✅ Complete | —       |
 | HD7  | Unit tests with mocked Supabase client covering HealthDataRepository (`test/core/health_data_repo_test.dart`) | new                       | QA        | 1.5      | ✅ Complete | HD5-HD6 |
-| HD8  | Widget placeholder files (`widgets/README.md`) explaining upcoming widgets & style contract                   | new                       | mobile    | 0.5      | ⚪ Planned  | HD1     |
-| HD9  | Add README inside `core/health_data/` outlining extension guidelines                                          | new                       | DX        | 0.5      | ⚪ Planned  | All     |
-| HD10 | Update `docs/architecture/auto_flutter_architecture.md` + new diagram                                         | docs                      | DX        | 1        | ⚪ Planned  | All     |
-| HD11 | Ensure CI (make ci-fast) runs flutter tests in `core/health_data/`                                            | CI                        | dev-infra | 0.5      | ⚪ Planned  | HD7     |
+| HD8  | Widget placeholder files (`widgets/README.md`) explaining upcoming widgets & style contract                   | new                       | mobile    | 0.5      | ✅ Complete | HD1     |
+| HD9  | Add README inside `core/health_data/` outlining extension guidelines                                          | new                       | DX        | 0.5      | ✅ Complete | All     |
+| HD10 | Update `docs/architecture/auto_flutter_architecture.md` + new diagram                                         | docs                      | DX        | 1        | ✅ Complete | All     |
+| HD11 | Ensure CI (make ci-fast) runs flutter tests in `core/health_data/`                                            | CI                        | dev-infra | 0.5      | ✅ Complete | HD7     |
 
 _Total effort: ≈ 12 hrs (1.5 dev-days)._ Tasks HD2–HD5 can run concurrently
 after HD1.

--- a/docs/MVP_ROADMAP/1-7 Health Signals/epic_1-7_health_signals.md
+++ b/docs/MVP_ROADMAP/1-7 Health Signals/epic_1-7_health_signals.md
@@ -1,0 +1,99 @@
+### Epic: 1.7 · Health Signals
+
+**Module:** Core Mobile Experience & AI Coach **Status:** 🟡 Planned\
+**Dependencies:** `health_data` foundation sprint ⚪, UI Foundation layer ✅,
+Epic 1.8 – Momentum Score ⚪
+
+---
+
+## 📋 Epic Overview
+
+**Goal:** Surface both subjective (Perceived Energy Score) and objective (Manual
+Biometrics & Biometric Flags) health signals in the BEE app, store them
+centrally, and use them to enrich Momentum Score and coach interactions. Must
+keep code modular via `core/health_data/`, achieve ≥ 85 % test coverage, and
+respect Flutter 3.3.2a + Supabase rules.
+
+**Success Criteria:**
+
+- ≥ 80 % of active users log at least one PES entry within first week
+  post-launch.
+- Manual Biometrics form completion error rate < 2 %.
+- Biometric-trigger chat prompts achieve ≥ 20 % reply rate.
+- Momentum Score updates < 5 min from PES/Biometrics events in staging.
+- WCAG AA compliance; no magic numbers (use `responsive_services.dart`,
+  `theme.dart`).
+- `flutter analyze --fatal-warnings` passes; overall coverage ≥ 85 %.
+
+---
+
+## 🏁 Milestone Breakdown
+
+### M1.7.1 · Perceived Energy Score System
+
+| Task | Description                                                         | Hours | Status     |
+| ---- | ------------------------------------------------------------------- | ----- | ---------- |
+| T1   | Build `EnergyInputSlider` widget (emoji 1-5) with Riverpod provider | 6h    | ⚪ Planned |
+| T2   | Create PES trend spark-line widget on Momentum screen               | 4h    | ⚪ Planned |
+| T3   | Persist entries via `HealthDataRepository.insertEnergyLevel()`      | 2h    | ⚪ Planned |
+| T4   | Daily prompt scheduler (default daily, user configurable)           | 3h    | ⚪ Planned |
+| T5   | Edge function call `updateMomentumScore()` (+10 pts) on insert      | 3h    | ⚪ Planned |
+
+**Deliverables:** Flutter widgets, provider logic, Supabase integration,
+edge-function hook.
+
+**Acceptance Criteria:** Users can log energy in ≤ 3 taps; new entry reflects in
+Momentum gauge within 5 min; unit/widget tests ≥ 90 % for widgets & provider.
+
+---
+
+### M1.7.2 · Manual Biometrics & Metabolic Health Score
+
+| Task | Description                                                          | Hours | Status     |
+| ---- | -------------------------------------------------------------------- | ----- | ---------- |
+| T1   | Build `BiometricManualInputForm` using `HealthInputField` components | 8h    | ⚪ Planned |
+| T2   | Add numeric/unit validation (lbs↔kg, cm↔ft/in) using core validators | 4h    | ⚪ Planned |
+| T3   | Implement `MetabolicHealthScoreService` (z-score → percentile)       | 4h    | ⚪ Planned |
+| T4   | Profile tile with latest MHS & 30-day trendline                      | 4h    | ⚪ Planned |
+| T5   | Persist data via `HealthDataRepository.insertBiometrics()`           | 2h    | ⚪ Planned |
+| T6   | Send Momentum modifier & coach context update on save                | 3h    | ⚪ Planned |
+
+**Deliverables:** Biometrics form UI, backend CRUD, MHS calculation, profile
+display.
+
+**Acceptance Criteria:** Valid inputs required; MHS visible immediately on save;
+calculation unit tests ≥ 95 % accuracy vs reference dataset.
+
+---
+
+### M1.7.3 · Biometric-Trigger Logic
+
+| Task | Description                                                            | Hours | Status     |
+| ---- | ---------------------------------------------------------------------- | ----- | ---------- |
+| T1   | Create `biometric_flags` table + RLS                                   | 3h    | ⚪ Planned |
+| T2   | Edge function `biometric_flag_detector@1.0.0` (steps/sleep drop rules) | 6h    | ⚪ Planned |
+| T3   | AI Coach prompt integration with template variants                     | 4h    | ⚪ Planned |
+| T4   | Momentum score update when user confirms disengagement                 | 3h    | ⚪ Planned |
+| T5   | Integration tests with Supabase emulator & mocked coach API            | 3h    | ⚪ Planned |
+
+**Deliverables:** Flag detection function, coach prompt flow, updated Momentum
+logic, tests.
+
+**Acceptance Criteria:** Flag detection latency < 2 min post-cron; coach prompt
+asks relevant question; unit + integration tests ≥ 90 %.
+
+---
+
+## ⏱ Status Flags
+
+⚪ Planned 🔵 In Progress ✅ Complete
+
+---
+
+## 🔗 Dependencies
+
+- `~/.bee_secrets/supabase.env` for Supabase creds.
+- Flutter 3.3.2a + Riverpod v2.
+- Epic 1.8 Momentum Score consumer for score modifiers.
+- AI Coach Conversation Engine for chat prompt delivery.
+- CI pipeline enforcing `--fatal-warnings`, ≥ 85 % coverage.

--- a/docs/architecture/auto_flutter_architecture.md
+++ b/docs/architecture/auto_flutter_architecture.md
@@ -69,6 +69,33 @@ be flipped to an _error_ after adoption reaches ≥ 80 %.
 - Navigation & dialog semantics follow Flutter a11y recommendations; new widgets
   include semantic labels where appropriate.
 
+## Health Data Module
+
+The `core/health_data/` module acts as a **domain-centric slice** that unifies
+models, validators, repository layer, and (upcoming) widgets dealing with user
+health signals.
+
+```
+app/lib/core/health_data/
+  models/            ← EnergyLevel, BiometricManualInput, MetabolicScore
+  services/          ← HealthDataRepository (Riverpod)
+  validators/        ← numeric_validators.dart
+  widgets/           ← EnergyInputSlider, BiometricsForm, …
+```
+
+### Data flow
+
+```mermaid
+graph TD;
+  models["Models\nEnergyLevel & BiometricManualInput"] --> repo["HealthDataRepository"];
+  validators["Validators\nnumeric_validators.dart"] --> repo;
+  repo -->|"CRUD"| supabase["Supabase Tables\nenergy_levels\nbiometric_manual_inputs"];
+  widgets["Widgets\nEnergyInputSlider / BiometricsForm"] --> repo;
+```
+
+The repository caches in memory and syncs with Supabase tables secured by
+Row-Level Security (RLS).
+
 ---
 
-_Last updated: 2025-07-17_
+_Last updated: 2025-07-18_


### PR DESCRIPTION
This PR finalises the Health-Data Module Foundation sprint by completing tasks HD8–HD11.\n\nChanges include:\n• Expanded widgets README with planned components, styling contract, data flow, and testing guidance.\n• Added module-level README under core/health_data explaining purpose, structure, extension points, and coverage goals.\n• Updated architecture doc with new Health Data Module section and Mermaid diagram.\n• Updated sprint PRD to mark tasks HD8-HD11 as complete.\n• Minor pubspec.lock dependency metadata update.\n\nAll tests and linters pass via make ci-fast. Ready for review.:,