### PR TITLE
feat(health-signals): implement T4 daily prompt scheduler\n\nAdds Not…

### DIFF
--- a/app/lib/features/health_signals/pes/pes_providers.dart
+++ b/app/lib/features/health_signals/pes/pes_providers.dart
@@ -2,6 +2,9 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:app/core/health_data/models/energy_level.dart';
 import 'package:app/core/health_data/services/health_data_repository.dart';
 import 'package:app/core/providers/supabase_provider.dart';
+import 'package:flutter/material.dart';
+import 'services/notification_scheduler_service.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 /// Holds the currently selected perceived energy score (1–5).
 /// `null` indicates no selection yet.
@@ -28,3 +31,57 @@ final pesTrendProvider = FutureProvider.autoDispose<List<EnergyLevelEntry>>((
 
   return latest;
 });
+
+// ---------------------------------------------------------------------------
+// Daily Prompt Scheduling
+// ---------------------------------------------------------------------------
+
+/// Provides a fully-initialised [NotificationSchedulerService].
+final notificationSchedulerProvider =
+    FutureProvider<NotificationSchedulerService>((ref) async {
+      return NotificationSchedulerService.create();
+    });
+
+/// Async notifier that manages the daily prompt time (defaults to 09:00 local),
+/// persists changes via `shared_preferences`, and reschedules notifications.
+class DailyPromptController extends AsyncNotifier<TimeOfDay> {
+  static const _hourKey = 'dailyPromptHour';
+  static const _minuteKey = 'dailyPromptMinute';
+
+  @override
+  Future<TimeOfDay> build() async {
+    final prefs = await SharedPreferences.getInstance();
+    final hour = prefs.getInt(_hourKey) ?? 9;
+    final minute = prefs.getInt(_minuteKey) ?? 0;
+
+    // Ensure a prompt is always scheduled on first build.
+    final scheduler = await ref.watch(notificationSchedulerProvider.future);
+    await scheduler.scheduleDailyPrompt(TimeOfDay(hour: hour, minute: minute));
+
+    return TimeOfDay(hour: hour, minute: minute);
+  }
+
+  /// Updates the preferred prompt [time] and reschedules notification.
+  Future<void> updateTime(TimeOfDay time) async {
+    state = const AsyncValue.loading();
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setInt(_hourKey, time.hour);
+    await prefs.setInt(_minuteKey, time.minute);
+
+    final scheduler = await ref.watch(notificationSchedulerProvider.future);
+    await scheduler.scheduleDailyPrompt(time);
+    state = AsyncValue.data(time);
+  }
+
+  /// Disables the PES daily prompt entirely.
+  Future<void> disablePrompt() async {
+    final scheduler = await ref.watch(notificationSchedulerProvider.future);
+    await scheduler.cancelPrompt();
+  }
+}
+
+/// Global provider for widgets to watch & mutate prompt time.
+final dailyPromptControllerProvider =
+    AsyncNotifierProvider<DailyPromptController, TimeOfDay>(
+      DailyPromptController.new,
+    );

--- a/app/lib/features/health_signals/pes/services/notification_scheduler_service.dart
+++ b/app/lib/features/health_signals/pes/services/notification_scheduler_service.dart
@@ -1,0 +1,89 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+import 'package:flutter_timezone/flutter_timezone.dart';
+import 'package:timezone/data/latest.dart' as tz;
+import 'package:timezone/timezone.dart' as tz;
+
+/// Handles local notification scheduling for the Perceived Energy Score (PES)
+/// daily prompt. Ensures notifications fire at **09:00 local** by default and
+/// respect the user’s current time-zone even after travel or daylight-saving
+/// changes.
+class NotificationSchedulerService {
+  NotificationSchedulerService._(this._plugin);
+
+  /// Factory constructor to perform one-time plugin + timezone initialisation.
+  static Future<NotificationSchedulerService> create() async {
+    final plugin = FlutterLocalNotificationsPlugin();
+
+    // Initialise platform-specific settings.
+    const androidInit = AndroidInitializationSettings('@mipmap/ic_launcher');
+    const iosInit = DarwinInitializationSettings();
+    const initSettings = InitializationSettings(
+      android: androidInit,
+      iOS: iosInit,
+    );
+    await plugin.initialize(initSettings);
+
+    // Initialise timezone data and bind to the device’s current zone.
+    tz.initializeTimeZones();
+    final String currentTz = await FlutterTimezone.getLocalTimezone();
+    tz.setLocalLocation(tz.getLocation(currentTz));
+
+    return NotificationSchedulerService._(plugin);
+  }
+
+  final FlutterLocalNotificationsPlugin _plugin;
+
+  /// Schedules (or reschedules) a daily prompt at the given [time]. Any existing
+  /// PES prompt is cancelled first to avoid duplicates.
+  Future<void> scheduleDailyPrompt(TimeOfDay time) async {
+    // Cancel any existing schedule.
+    await cancelPrompt();
+
+    // Compute the next occurrence of the desired local time.
+    final now = tz.TZDateTime.now(tz.local);
+    var scheduledDate = tz.TZDateTime(
+      tz.local,
+      now.year,
+      now.month,
+      now.day,
+      time.hour,
+      time.minute,
+    );
+    if (scheduledDate.isBefore(now)) {
+      scheduledDate = scheduledDate.add(const Duration(days: 1));
+    }
+
+    // Schedule the notification.
+    await _plugin.zonedSchedule(
+      _pesPromptNotificationId,
+      'Daily Check-In',
+      'How energized do you feel today?',
+      scheduledDate,
+      const NotificationDetails(
+        android: AndroidNotificationDetails(
+          _pesPromptChannelId,
+          'Daily PES Prompt',
+          channelDescription:
+              'Daily reminder to record your perceived energy score',
+          importance: Importance.defaultImportance,
+          priority: Priority.defaultPriority,
+        ),
+        iOS: DarwinNotificationDetails(presentAlert: true, presentSound: true),
+      ),
+      androidScheduleMode: AndroidScheduleMode.exactAllowWhileIdle,
+      uiLocalNotificationDateInterpretation:
+          UILocalNotificationDateInterpretation.absoluteTime,
+      matchDateTimeComponents: DateTimeComponents.time,
+    );
+  }
+
+  /// Cancels the currently scheduled PES prompt (if any).
+  Future<void> cancelPrompt() async {
+    await _plugin.cancel(_pesPromptNotificationId);
+  }
+
+  /// Constants =================================================================
+  static const int _pesPromptNotificationId = 9001;
+  static const String _pesPromptChannelId = 'daily_pes_prompt';
+}

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -51,6 +51,9 @@ dependencies:
   firebase_messaging: ^14.7.10
   permission_handler: ^11.2.0
   app_links: ^3.5.1
+  flutter_local_notifications: ^16.3.0
+  flutter_timezone: ^1.0.7
+  timezone: ^0.9.2
 
   # Monitoring & Error Tracking
   sentry_flutter: ^8.2.0

--- a/app/test/features/health_signals/pes/daily_prompt_controller_test.dart
+++ b/app/test/features/health_signals/pes/daily_prompt_controller_test.dart
@@ -1,0 +1,83 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:app/features/health_signals/pes/pes_providers.dart';
+import 'package:app/features/health_signals/pes/services/notification_scheduler_service.dart';
+
+// -----------------------------------------------------------------------------
+// Test doubles
+// -----------------------------------------------------------------------------
+class _FakeScheduler implements NotificationSchedulerService {
+  TimeOfDay? lastScheduled;
+  int cancelCount = 0;
+
+  @override
+  Future<void> cancelPrompt() async {
+    cancelCount += 1;
+  }
+
+  @override
+  Future<void> scheduleDailyPrompt(TimeOfDay time) async {
+    lastScheduled = time;
+  }
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('DailyPromptController', () {
+    late _FakeScheduler fakeScheduler;
+
+    setUp(() async {
+      SharedPreferences.setMockInitialValues({});
+      fakeScheduler = _FakeScheduler();
+    });
+
+    test('schedules default 09:00 prompt on first build', () async {
+      final container = ProviderContainer(
+        overrides: [
+          notificationSchedulerProvider.overrideWith(
+            (ref) async => fakeScheduler,
+          ),
+        ],
+      );
+
+      addTearDown(container.dispose);
+
+      final time = await container.read(dailyPromptControllerProvider.future);
+      expect(time.hour, 9);
+      expect(time.minute, 0);
+      expect(fakeScheduler.lastScheduled?.hour, 9);
+      expect(fakeScheduler.lastScheduled?.minute, 0);
+    });
+
+    test('updateTime persists preference and reschedules', () async {
+      final container = ProviderContainer(
+        overrides: [
+          notificationSchedulerProvider.overrideWith(
+            (ref) async => fakeScheduler,
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+      final controller = container.read(dailyPromptControllerProvider.notifier);
+
+      await controller.updateTime(const TimeOfDay(hour: 18, minute: 30));
+
+      // Verify scheduler called with new time.
+      expect(fakeScheduler.lastScheduled?.hour, 18);
+      expect(fakeScheduler.lastScheduled?.minute, 30);
+
+      // Verify state updated.
+      final value = await container.read(dailyPromptControllerProvider.future);
+      expect(value.hour, 18);
+      expect(value.minute, 30);
+
+      // Verify prefs persisted.
+      final prefs = await SharedPreferences.getInstance();
+      expect(prefs.getInt('dailyPromptHour'), 18);
+      expect(prefs.getInt('dailyPromptMinute'), 30);
+    });
+  });
+}

--- a/docs/MVP_ROADMAP/1-7 Health Signals/Milestones, Tasks, and Epic Docs/M1.7.1_perceived_energy_score_system.md
+++ b/docs/MVP_ROADMAP/1-7 Health Signals/Milestones, Tasks, and Epic Docs/M1.7.1_perceived_energy_score_system.md
@@ -28,8 +28,8 @@ the AI Coach can react in near-real-time.
 | ------- | ------------------------------------------------------------------- | -------- | ------ |
 | T1      | Build `EnergyInputSlider` widget (emoji 1-5) with Riverpod provider | 6h       | ✅     |
 | T2      | Create `PesTrendSparkline` widget for Momentum screen               | 4h       | ✅     |
-| T3      | Persist entries via `HealthDataRepository.insertEnergyLevel()`      | 2h       | 🟡     |
-| T4      | Daily prompt scheduler (default daily, user-configurable)           | 3h       | 🟡     |
+| T3      | Persist entries via `HealthDataRepository.insertEnergyLevel()`      | 2h       | ✅     |
+| T4      | Daily prompt scheduler (default daily, user-configurable)           | 3h       | ✅     |
 | T5      | Invoke edge function `updateMomentumScore()` (+10 pts) after insert | 3h       | 🟡     |
 
 _Total: 18 h_


### PR DESCRIPTION
…ificationSchedulerService leveraging flutter_local_notifications + timezone for daily PES reminders.\nIntroduces DailyPromptController with persistence+reschedule logic via Riverpod.\nUnit tests cover default scheduling and time updates.\nDependencies: flutter_local_notifications, flutter_timezone, timezone.\nUpdates docs milestone status to ✅.\n