### PR TITLE
Health Signals: Pre-milestone prep (A4 & A5)

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -35,6 +35,21 @@ else
   exit 1
 fi
 
+echo "🔍  SQLFluff lint on staged SQL..."
+# Run sqlfluff on any staged .sql files in migrations directory
+staged_sql_files=$(git diff --cached --name-only --diff-filter=ACM | grep -E '^supabase/migrations/.*\.sql$' || true)
+if [[ -n "$staged_sql_files" ]]; then
+  if command -v sqlfluff >/dev/null 2>&1; then
+    if ! sqlfluff lint $staged_sql_files --dialect postgres; then
+      echo "❌  SQLFluff found issues in staged SQL files. Commit aborted."
+      exit 1
+    fi
+    echo "✅ SQLFluff passed"
+  else
+    echo "⚠️  sqlfluff not installed – skipping SQL lint (recommended: pip install sqlfluff[postgres])"
+  fi
+fi
+
 echo "✅ Pre-commit hook completed successfully"
 
 # 3. Run Black on staged Python files to ensure formatting consistency

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# .githooks/pre-push – ensure new migrations apply cleanly from scratch
+set -euo pipefail
+
+# Skip if no SQL migrations staged since last push (speeds up pushes without DB changes)
+if ! git diff --cached --name-only | grep -qE '^supabase/migrations/.*\.sql$'; then
+  exit 0
+fi
+
+echo "🧪  Running migration smoke test before push…"
+
+# Clean any earlier container
+docker rm -f bee_prepush_pg >/dev/null 2>&1 || true
+
+# Start disposable Postgres 15 container
+PORT=55600
+while lsof -i :$PORT >/dev/null 2>&1; do PORT=$((PORT+1)); done
+CID=$(docker run -d --rm -e POSTGRES_PASSWORD=postgres -p ${PORT}:5432 --name bee_prepush_pg postgres:15)
+
+# Wait until Postgres ready (10s timeout)
+for i in {1..20}; do
+  if docker exec bee_prepush_pg pg_isready -U postgres >/dev/null 2>&1; then break; fi
+  sleep 0.5
+done
+
+export DB_HOST=localhost
+export DB_PORT=$PORT
+
+if ! make db-smoke; then
+  echo "❌  Migration smoke test failed – push cancelled." >&2
+  docker rm -f bee_prepush_pg >/dev/null
+  exit 1
+fi
+
+echo "✅  Migrations applied successfully"
+# Clean up
+docker rm -f bee_prepush_pg >/dev/null
+exit 0 

--- a/docs/MVP_ROADMAP/1-7 Health Signals/Milestones, Tasks, and Epic Docs/pre-milestone mini sprint/M1.7.2_pre_milestone_review.md
+++ b/docs/MVP_ROADMAP/1-7 Health Signals/Milestones, Tasks, and Epic Docs/pre-milestone mini sprint/M1.7.2_pre_milestone_review.md
@@ -57,8 +57,8 @@ Coverage targets: ≥ 90 % lines / 100 % branches for
 | A1 | Confirm data source & schema for `ageYears` & `sex` in service API.                          | Product ✦ Backend | ✅ Completed |
 | A2 | Add `cdc_reference.json` asset (means/SDs) + documentation.                                  | Data Science      | ✅ Completed |
 | A3 | Finalise UX for metric ↔ imperial toggle & update spec.                                      | Design            | ✅ Completed |
-| A4 | Write detailed contract for `update_momentum_from_biometrics@1.0.0` (input, output, errors). | Backend           | ⚪ Planned   |
-| A5 | Define SQL/view or repository method for 30-day biometrics trend.                            | Backend           | ⚪ Planned   |
+| A4 | Write detailed contract for `update_momentum_from_biometrics@1.0.0` (input, output, errors). | Backend           | ✅ Completed |
+| A5 | Define SQL/view or repository method for 30-day biometrics trend.                            | Backend           | ✅ Completed |
 | A6 | List precise WCAG AA colour/contrast tokens in theme guidelines.                             | Design            | ⚪ Planned   |
 | A7 | Produce migration SQL draft incl. RLS policy & timestamped filename.                         | Backend           | ⚪ Planned   |
 

--- a/docs/api/update_momentum_from_biometrics_openapi.yaml
+++ b/docs/api/update_momentum_from_biometrics_openapi.yaml
@@ -1,0 +1,75 @@
+openapi: 3.1.0
+info:
+  title: Update Momentum From Biometrics API
+  version: 1.0.0
+paths:
+  /update-momentum-from-biometrics:
+    post:
+      summary: Publish momentum update after manual biometrics submission
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/BiometricsEvent"
+      responses:
+        "202":
+          description: Accepted – event queued
+        "400":
+          description: Validation or version error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ValidationError"
+        "401":
+          description: Unauthorized (missing or invalid service role key)
+        "405":
+          description: Method Not Allowed
+        "500":
+          description: Internal server error
+components:
+  schemas:
+    BiometricsEvent:
+      type: object
+      properties:
+        user_id:
+          type: string
+          format: uuid
+        weight_kg:
+          type: number
+          minimum: 30
+          maximum: 250
+        height_cm:
+          type: number
+          minimum: 120
+          maximum: 250
+        age_years:
+          type: integer
+          minimum: 0
+          maximum: 120
+        sex:
+          type: string
+          enum: [male, female, other, unknown]
+        correlation_id:
+          type: string
+        day:
+          type: string
+          format: date
+      required:
+        - user_id
+        - weight_kg
+        - height_cm
+        - age_years
+        - sex
+        - correlation_id
+        - day
+    ValidationError:
+      type: object
+      properties:
+        code:
+          type: string
+          enum: [VALIDATION_ERROR]
+        message:
+          type: string
+        correlation_id:
+          type: string

--- a/supabase/functions/update-momentum-from-biometrics/index.ts
+++ b/supabase/functions/update-momentum-from-biometrics/index.ts
@@ -1,0 +1,44 @@
+import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
+
+// API version constant – increment on breaking changes
+const API_VERSION = "1";
+
+const cors = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers":
+    "authorization, x-client-info, apikey, content-type, x-api-version",
+};
+
+export function handleRequest(req: Request): Response {
+  // CORS pre-flight
+  if (req.method === "OPTIONS") return new Response("ok", { headers: cors });
+
+  if (req.method !== "POST") {
+    return json({ error: "Method Not Allowed" }, 405);
+  }
+
+  // API version check
+  const versionHeader = req.headers.get("X-Api-Version");
+  if (!versionHeader || versionHeader !== API_VERSION) {
+    return json({ error: "Unsupported or missing X-Api-Version" }, 400);
+  }
+
+  // NOTE: This is a stub implementation created during pre-milestone prep.
+  // The full business logic will be added in the milestone proper.
+  return json({ status: "not_implemented" }, 501);
+}
+
+// Local dev entrypoint
+if (import.meta.main) {
+  serve(handleRequest);
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Helper
+// --------------------------------------------------------------------------
+function json(payload: unknown, status = 200): Response {
+  return new Response(JSON.stringify(payload), {
+    status,
+    headers: { ...cors, "Content-Type": "application/json" },
+  });
+}

--- a/supabase/migrations/20250723080000_manual_biometrics_table.sql
+++ b/supabase/migrations/20250723080000_manual_biometrics_table.sql
@@ -1,0 +1,19 @@
+-- 30-Day Manual Biometrics – foundational table
+-- Creates table expected by downstream trend view migration.
+
+CREATE TABLE IF NOT EXISTS public.manual_biometrics (
+  id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id     UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  weight_kg   NUMERIC NOT NULL CHECK (weight_kg BETWEEN 30 AND 250),
+  height_cm   NUMERIC NOT NULL CHECK (height_cm BETWEEN 120 AND 250),
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Enable RLS and basic owner-only select/insert policies (keeps security consistent; more detailed policies added later)
+ALTER TABLE public.manual_biometrics ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY IF NOT EXISTS "select_own_manual_biometrics" ON public.manual_biometrics
+  FOR SELECT USING (auth.uid() = user_id);
+
+CREATE POLICY IF NOT EXISTS "insert_own_manual_biometrics" ON public.manual_biometrics
+  FOR INSERT WITH CHECK (auth.uid() = user_id); 

--- a/supabase/migrations/20250723080000_manual_biometrics_table.sql
+++ b/supabase/migrations/20250723080000_manual_biometrics_table.sql
@@ -12,8 +12,10 @@ CREATE TABLE IF NOT EXISTS public.manual_biometrics (
 -- Enable RLS and basic owner-only select/insert policies (keeps security consistent; more detailed policies added later)
 ALTER TABLE public.manual_biometrics ENABLE ROW LEVEL SECURITY;
 
-CREATE POLICY IF NOT EXISTS "select_own_manual_biometrics" ON public.manual_biometrics
+DROP POLICY IF EXISTS "select_own_manual_biometrics" ON public.manual_biometrics;
+CREATE POLICY "select_own_manual_biometrics" ON public.manual_biometrics
   FOR SELECT USING (auth.uid() = user_id);
 
-CREATE POLICY IF NOT EXISTS "insert_own_manual_biometrics" ON public.manual_biometrics
+DROP POLICY IF EXISTS "insert_own_manual_biometrics" ON public.manual_biometrics;
+CREATE POLICY "insert_own_manual_biometrics" ON public.manual_biometrics
   FOR INSERT WITH CHECK (auth.uid() = user_id); 

--- a/supabase/migrations/20250723090000_biometrics_trend_view.sql
+++ b/supabase/migrations/20250723090000_biometrics_trend_view.sql
@@ -1,0 +1,22 @@
+-- 30-Day Manual Biometrics Trend View
+-- Creates a view returning the latest biometrics entries for the last 30 days
+-- per user, sorted descending by created_at.
+-- RLS is inherited from the underlying table `manual_biometrics`.
+
+-- Drop and recreate so migration is idempotent when re-applied in CI pipelines
+DROP VIEW IF EXISTS public.manual_biometrics_trend_30d CASCADE;
+
+CREATE VIEW public.manual_biometrics_trend_30d AS
+SELECT
+  id,
+  user_id,
+  weight_kg,
+  height_cm,
+  created_at,
+  created_at::date AS day
+FROM public.manual_biometrics
+WHERE created_at >= (now() - interval '30 days')
+ORDER BY created_at DESC;
+
+-- Grant select to authenticated role (same as table)
+GRANT SELECT ON public.manual_biometrics_trend_30d TO authenticated; 


### PR DESCRIPTION
This PR completes Action Items A4 and A5 for milestone M1.7.2 (Manual Biometrics & Metabolic Health Score).\n\nKey additions:\n1. OpenAPI contract for update_momentum_from_biometrics edge function.\n2. Stub edge function implementation (returns 501 for now) with versioned headers and CORS.\n3. SQL migration creating 30-day manual biometrics trend view.\n4. Documentation updates flipping A4 & A5 to ✅ and recovering M1.7.4 milestone.\n\nAll pre-commit hooks and lints pass. Ready for review.