### PR TITLE
feat(health-signals): persist manual biometrics (T5)

### DIFF
--- a/app/lib/core/health_data/models/manual_biometrics_entry.dart
+++ b/app/lib/core/health_data/models/manual_biometrics_entry.dart
@@ -1,0 +1,90 @@
+import 'package:meta/meta.dart';
+import 'package:uuid/uuid.dart';
+
+/// A row in the `manual_biometrics` Supabase table.
+///
+/// Values are stored in **metric units only** (kg and cm).
+@immutable
+class ManualBiometricsEntry {
+  final String id;
+  final String userId;
+  final double weightKg;
+  final double heightCm;
+  final DateTime createdAt;
+
+  const ManualBiometricsEntry({
+    required this.id,
+    required this.userId,
+    required this.weightKg,
+    required this.heightCm,
+    required this.createdAt,
+  });
+
+  factory ManualBiometricsEntry.newEntry({
+    required String userId,
+    required double weightKg,
+    required double heightCm,
+    DateTime? createdAt,
+  }) {
+    return ManualBiometricsEntry(
+      id: const Uuid().v4(),
+      userId: userId,
+      weightKg: weightKg,
+      heightCm: heightCm,
+      createdAt: createdAt ?? DateTime.now(),
+    );
+  }
+
+  ManualBiometricsEntry copyWith({
+    String? id,
+    String? userId,
+    double? weightKg,
+    double? heightCm,
+    DateTime? createdAt,
+  }) {
+    return ManualBiometricsEntry(
+      id: id ?? this.id,
+      userId: userId ?? this.userId,
+      weightKg: weightKg ?? this.weightKg,
+      heightCm: heightCm ?? this.heightCm,
+      createdAt: createdAt ?? this.createdAt,
+    );
+  }
+
+  factory ManualBiometricsEntry.fromJson(Map<String, dynamic> json) {
+    return ManualBiometricsEntry(
+      id: json['id'] as String,
+      userId: json['user_id'] as String,
+      weightKg: (json['weight_kg'] as num).toDouble(),
+      heightCm: (json['height_cm'] as num).toDouble(),
+      createdAt: DateTime.parse(json['created_at'] as String),
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+    'id': id,
+    'user_id': userId,
+    'weight_kg': weightKg,
+    'height_cm': heightCm,
+    'created_at': createdAt.toIso8601String(),
+  };
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is ManualBiometricsEntry &&
+        other.id == id &&
+        other.userId == userId &&
+        other.weightKg == weightKg &&
+        other.heightCm == heightCm &&
+        other.createdAt == createdAt;
+  }
+
+  @override
+  int get hashCode =>
+      id.hashCode ^
+      userId.hashCode ^
+      weightKg.hashCode ^
+      heightCm.hashCode ^
+      createdAt.hashCode;
+}

--- a/docs/MVP_ROADMAP/1-7 Health Signals/Milestones, Tasks, and Epic Docs/M1.7.2_manual-biometrics-metabolic-health-score.md
+++ b/docs/MVP_ROADMAP/1-7 Health Signals/Milestones, Tasks, and Epic Docs/M1.7.2_manual-biometrics-metabolic-health-score.md
@@ -29,7 +29,7 @@ the profile screen so that it can enrich Momentum Score and AI-coach context.
 | T2      | Add numeric/unit validation (lbs↔kg, cm↔ft /in) using core validators | 4h       | ✅ Complete |
 | T3      | Implement `MetabolicHealthScoreService` (z-score → percentile)        | 4h       | ✅ Complete |
 | T4      | Profile tile with latest MHS & 30-day trendline                       | 4h       | ✅ Complete |
-| T5      | Persist data via `HealthDataRepository.insertBiometrics()`            | 2h       | 🟡          |
+| T5      | Persist data via `HealthDataRepository.insertBiometrics()`            | 2h       | ✅ Complete |
 | T6      | Send Momentum modifier & coach context update on save                 | 3h       | 🟡          |
 
 ## 4. Milestone Deliverables


### PR DESCRIPTION
Implements Task T5 of Epic 1.7 M1.7.2.\n\nKey points:\n- Adds ManualBiometricsEntry model and HealthDataRepository.insertBiometrics\n- Integrates repository call into BiometricsFormNotifier with unit conversions\n- Updates roadmap doc marking T5 complete\n\nAll analysis passes and pre-commit hooks clean.