### PR TITLE
M1.7.3 mini-sprint: Complete A5-A7 readiness tasks

### DIFF
--- a/docs/MVP_ROADMAP/1-7 Health Signals/Milestones, Tasks, and Epic Docs/M1.7.3_biometric_trigger_logic.md
+++ b/docs/MVP_ROADMAP/1-7 Health Signals/Milestones, Tasks, and Epic Docs/M1.7.3_biometric_trigger_logic.md
@@ -36,8 +36,9 @@ disengagement, and trigger AI Coach prompts plus Momentum Score adjustments.
 - RLS policies enforcing owner access on `biometric_flags`.
 - Edge function code under `supabase/functions/biometric-flag-detector/` tagged
   `v1.0.0`.
-- Prompt templates in `app/lib/core/prompts/biometric_drop.dart` (or shared TS
-  helper for edge).
+- Prompt templates in
+  `supabase/functions/ai-coaching-engine/prompt_templates/biometric_drop.ts`
+  (canonical **single source of truth**).
 - Service layer update `core/health_data/biometric_flag_service.dart`.
 - Integration test suite
   `supabase/functions/tests/biometric_flag_detector.test.ts`.
@@ -106,8 +107,10 @@ CREATE POLICY "Owner can read/write own flags" ON biometric_flags
 }
 ```
 
-- Prompt templates live in `_shared/coachPromptTemplates.ts` with variants for
-  `low_steps` & `low_sleep`.
+- Prompt templates live in
+  `supabase/functions/ai-coaching-engine/prompt_templates/` with variants
+  `biometric_drop_low_steps.ts` & `biometric_drop_low_sleep.ts`. **This
+  directory is the system of record** for all AI Coach prompt templates.
 
 ### 4. Momentum Score Update
 
@@ -135,6 +138,13 @@ All tests must reach ≥90 % line & branch coverage.
 - Respect `analysis_options.yaml`; null-safety enforced.
 - No file >300 LOC; split into data-layer, service-layer, UI.
 
+### 7. Rollback & Dedup Strategy
+
+Refer to `rollback_dedup_biometric_flags.md` for the full rollback and automatic
+deduplication procedure. A nightly cron edge function
+`biometric_flag_deduper@1.0.0` enforces 24 h suppression and merges duplicates
+according to the rules outlined there.
+
 ## Acceptance Criteria
 
 - Migration applies cleanly with `supabase db reset`.
@@ -147,4 +157,6 @@ All tests must reach ≥90 % line & branch coverage.
 - Supabase secrets: `~/.bee_secrets/supabase.env`.
 - Requires step/sleep aggregates from Health Data Ingestion pipeline.
 - Depends on AI Coach Conversation Engine endpoint `/coach_prompt`.
-- Momentum Score modifier listener (Epic 1.8) must accept penalty events.
+- Momentum Score modifier listener (Epic 1.8) must accept penalty events. M1.8.2
+  **Momentum Listener** must be deployed _before_ enabling Step 4 (Momentum
+  Score Update). QA for this milestone is blocked until Epic 1.8 passes CI.

--- a/docs/MVP_ROADMAP/1-7 Health Signals/Milestones, Tasks, and Epic Docs/pre-milestone mini sprint/M1.7.3_pre_milestone_review.md
+++ b/docs/MVP_ROADMAP/1-7 Health Signals/Milestones, Tasks, and Epic Docs/pre-milestone mini sprint/M1.7.3_pre_milestone_review.md
@@ -50,15 +50,15 @@ Edge-function p99 < 500 ms; Coach prompt latency < 30 s.
 
 ## Action Items
 
-| ID | Item                                                                           | Owner | Status       |
-| -- | ------------------------------------------------------------------------------ | ----- | ------------ |
-| A1 | Confirm Supabase cron quota & adjust schedule Cadence if needed.               | TBD   | ✅ Completed |
-| A2 | Define fallback logic for users with < 7 days data (e.g., require min 3 days). | TBD   | ✅ Completed |
-| A3 | Add composite index on `health_aggregates_daily (user_id, day)` in migration.  | TBD   | ✅ Completed |
-| A4 | Specify broadcast channel & RLS perms for `biometric_flag` events.             | TBD   | ✅ Completed |
-| A5 | Choose single source for prompt templates (Dart **or** TypeScript).            | TBD   | ⚪ Planned   |
-| A6 | Align timeline with Epic 1.8 dependency for Momentum listener.                 | TBD   | ⚪ Planned   |
-| A7 | Document rollback/dedup procedure for mis-flags.                               | TBD   | ⚪ Planned   |
+| ID | Item                                                                           | Owner  | Status       |
+| -- | ------------------------------------------------------------------------------ | ------ | ------------ |
+| A1 | Confirm Supabase cron quota & adjust schedule cadence if needed.               | TBD    | ✅ Completed |
+| A2 | Define fallback logic for users with < 7 days data (e.g., require min 3 days). | TBD    | ✅ Completed |
+| A3 | Add composite index on `health_aggregates_daily (user_id, day)` in migration.  | TBD    | ✅ Completed |
+| A4 | Specify broadcast channel & RLS perms for `biometric_flag` events.             | TBD    | ✅ Completed |
+| A5 | Choose single source for prompt templates (TypeScript path chosen).            | BeeDev | ✅ Completed |
+| A6 | Align timeline with Epic 1.8 dependency for Momentum listener.                 | BeeDev | ✅ Completed |
+| A7 | Document rollback/dedup procedure for mis-flags.                               | BeeDev | ✅ Completed |
 
 ---
 

--- a/docs/MVP_ROADMAP/1-7 Health Signals/Milestones, Tasks, and Epic Docs/rollback_dedup_biometric_flags.md
+++ b/docs/MVP_ROADMAP/1-7 Health Signals/Milestones, Tasks, and Epic Docs/rollback_dedup_biometric_flags.md
@@ -1,0 +1,87 @@
+### Biometric Flags – Rollback & Dedup Procedure
+
+_Belonging to Epic **1.7 Health Signals** · Applies to Milestone **M1.7.3 –
+Biometric-Trigger Logic**_
+
+---
+
+## 1️⃣ When to Use This Guide
+
+1. **False Positive Flag** – Edge-function logic incorrectly triggers a
+   `low_steps` or `low_sleep` flag.
+2. **User Correction** – User indicates data anomaly (e.g., forgot to wear
+   wearable).
+3. **Bulk Import** – Historical backfill inserts duplicate flags.
+
+---
+
+## 2️⃣ Deduplication Rules
+
+| Rule | Condition                                                                                           | Resolution                                                                                                           |
+| ---- | --------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
+| R1   | Multiple flags with **identical** `user_id`, `flag_type`, `detected_on::date`                       | Keep the **earliest** record; delete the rest.                                                                       |
+| R2   | A **resolved** flag exists and a **new unresolved** flag of the _same type_ arrives **within 24 h** | Mark the new flag as `resolved = true` and add JSON note `{ "source": "dedup", "note": "auto-resolved duplicate" }`. |
+| R3   | Flag row later deemed **false positive** by manual QA                                               | Update row → `resolved = true`, append `details->>'qa_note'`.                                                        |
+| R4   | User requests deletion of a flag (privacy request)                                                  | Hard‐delete the row using service role; log action in `audit_log`.                                                   |
+
+---
+
+## 3️⃣ Rollback Workflow (Manual)
+
+> **Tip:** Always run in a transaction when rolling back multiple rows.
+
+1. **Identify Flag(s)**
+   ```sql
+   SELECT *
+   FROM biometric_flags
+   WHERE user_id = '<uuid>'
+     AND detected_on::date BETWEEN '<start>' AND '<end>';
+   ```
+2. **Resolve or Delete** – if keeping historical trace, prefer resolve:
+   ```sql
+   UPDATE biometric_flags
+   SET resolved = TRUE,
+       details = jsonb_set(coalesce(details, '{}'::jsonb), '{rollback_reason}', '"manual_rollback"')
+   WHERE id = '<flag_id>';
+   ```
+   For hard delete:
+   ```sql
+   DELETE FROM biometric_flags WHERE id = '<flag_id>';
+   ```
+3. **Backfill Momentum Score** – if Momentum penalties were applied:
+   ```sql
+   -- Example: revert -10 penalty
+   INSERT INTO momentum_adjustments (user_id, delta, reason)
+   VALUES ('<uuid>', 10, 'rollback_biometric_flag');
+   ```
+4. **Broadcast Correction (Optional)** – notify clients to refresh flag list.
+   ```typescript
+   realtime.broadcast("biometric_flag_correction", { id: "<flag_id>" });
+   ```
+
+---
+
+## 4️⃣ Automated Nightly Job
+
+A cron‐based edge function `biometric_flag_deduper@1.0.0` should run daily at
+02:00 UTC to enforce R1 & R2 rules:
+
+```ts
+// pseudocode
+for (const flag of flagsFromLast7Days()) {
+    if (duplicateExists(flag)) {
+        resolveDuplicate(flag);
+    }
+}
+```
+
+The job must finish in < 300 ms (p95) and log actions to `audit_log`.
+
+---
+
+## 5️⃣ Audit & Monitoring
+
+- All rollbacks/dedups write to `audit_log` with `action`, `actor`, `target_id`,
+  and `metadata` JSON.
+- Grafana panel **Biometric Flags – Daily Dedups** tracks count per day.
+- Alert if nightly job resolves >1 % of new flags (potential logic regression).

--- a/supabase/functions/ai-coaching-engine/prompt_templates/biometric_drop_low_sleep.ts
+++ b/supabase/functions/ai-coaching-engine/prompt_templates/biometric_drop_low_sleep.ts
@@ -1,0 +1,5 @@
+export default `# Biometric Drop – Low Sleep 😴⏬
+Your user slept significantly less than their usual duration.
+1. Express concern in a supportive tone.
+2. Share one actionable sleep hygiene tip (e.g., winding down 30 min before bed).
+3. Reinforce that consistent rest supports their goals.`

--- a/supabase/functions/ai-coaching-engine/prompt_templates/biometric_drop_low_steps.ts
+++ b/supabase/functions/ai-coaching-engine/prompt_templates/biometric_drop_low_steps.ts
@@ -1,0 +1,5 @@
+export default `# Biometric Drop – Low Steps 🚶‍♂️⏬
+Your user has experienced a significant drop in their daily step count.
+1. Acknowledge the change with empathy.
+2. Offer one simple suggestion to resume movement (e.g., a 5-minute walk).
+3. Encourage them that small steps rebuild momentum.`


### PR DESCRIPTION
This PR completes tasks A5–A7 from the pre-milestone mini-sprint for Milestone M1.7.3 (Biometric-Trigger Logic).\n\nKey updates:\n• Selected TypeScript prompt templates as the canonical source and added biometric drop templates.\n• Aligned milestone timeline with Epic 1.8 dependency.\n• Added rollback/dedup procedure and integrated references into milestone docs.\n\nDocumentation-only change; no runtime code affected.