### PR TITLE
Health Signals: Complete Task T6 – Docs & Coverage

### DIFF
--- a/app/test/core/health_data/services/metabolic_health_score_service_edge_test.dart
+++ b/app/test/core/health_data/services/metabolic_health_score_service_edge_test.dart
@@ -1,0 +1,115 @@
+import 'dart:convert';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:app/core/health_data/services/metabolic_health_score_service.dart';
+import 'package:app/core/health_data/models/biometric_record.dart';
+import 'package:app/core/health_data/mhs_coefficient_repository.dart';
+import 'package:app/core/models/sex.dart';
+
+// A simple fake AssetBundle that returns the provided JSON string.
+class _FakeBundle extends CachingAssetBundle {
+  _FakeBundle(this._json);
+  final String _json;
+  @override
+  Future<String> loadString(String key, {bool cache = true}) async => _json;
+  @override
+  Future<ByteData> load(String key) async => ByteData(0);
+}
+
+void main() {
+  group('MetabolicHealthScoreService edge-case coverage', () {
+    late MetabolicHealthScoreService service;
+
+    // Minimal CDC reference JSON covering one male age-band – sufficient for tests.
+    const cdcJson = '''{
+      "male": {
+        "18-29": { "height_cm_mean": 175, "height_cm_sd": 7,
+                      "weight_kg_mean": 80,  "weight_kg_sd": 10 }
+      }
+    }''';
+
+    setUp(() {
+      service = MetabolicHealthScoreService(bundle: _FakeBundle(cdcJson));
+    });
+
+    test(
+      'calculateScore throws when weight or height is non-positive',
+      () async {
+        expect(
+          () => service.calculateScore(
+            weightKg: 0,
+            heightCm: 175,
+            ageYears: 25,
+            sex: Sex.male,
+          ),
+          throwsA(isA<ArgumentError>()),
+        );
+      },
+    );
+
+    test(
+      'calculateScore clamps extreme z-scores to 100th percentile',
+      () async {
+        final pct = await service.calculateScore(
+          weightKg: 300, // far above mean
+          heightCm: 500, // extreme height → |z| > 37 triggers fast-path CDF
+          ageYears: 25,
+          sex: Sex.male,
+        );
+        expect(pct, equals(100.0));
+      },
+    );
+
+    group('calculateMhs', () {
+      // JSON with deliberately extreme coefficients to exercise CDF edge paths.
+      final negCoeffJson = jsonEncode({
+        'non_hispanic_white_asian': {
+          'male': [-100, 0, 0, 0, 0, 0],
+        },
+      });
+
+      late MhsCoefficientRepository negRepo;
+
+      setUp(() {
+        negRepo = MhsCoefficientRepository.forBundle(_FakeBundle(negCoeffJson));
+      });
+
+      test('throws when TG is non-positive', () async {
+        const rec = BiometricRecord(
+          weightKg: 80,
+          heightCm: 175,
+          hdlMgDl: 50,
+          sbp: 120,
+          tgMgDl: 0, // invalid
+          fgMgDl: 90,
+          cohortKey: 'non_hispanic_white_asian',
+          sex: Sex.male,
+        );
+        expect(
+          () => service.calculateMhs(record: rec, coeffRepository: negRepo),
+          throwsA(isA<ArgumentError>()),
+        );
+      });
+
+      test('returns 0th percentile for extremely negative Z-score', () async {
+        const rec = BiometricRecord(
+          weightKg:
+              40, // low weight but irrelevant given huge negative intercept
+          heightCm: 160,
+          hdlMgDl: 40,
+          sbp: 110,
+          tgMgDl: 100,
+          fgMgDl: 80,
+          cohortKey: 'non_hispanic_white_asian',
+          sex: Sex.male,
+        );
+
+        final mhs = await service.calculateMhs(
+          record: rec,
+          coeffRepository: negRepo,
+        );
+        expect(mhs, equals(0.0));
+      });
+    });
+  });
+}

--- a/app/test/features/health_signals/widgets/metabolic_score_gauge_additional_test.dart
+++ b/app/test/features/health_signals/widgets/metabolic_score_gauge_additional_test.dart
@@ -1,0 +1,49 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:app/features/health_signals/widgets/metabolic_score_gauge.dart';
+
+void main() {
+  group('MetabolicScoreGauge additional coverage', () {
+    testWidgets('displays correct band label for “On Track” category', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        const ProviderScope(
+          child: MaterialApp(
+            home: Scaffold(body: Center(child: MetabolicScoreGauge(mhs: 45))),
+          ),
+        ),
+      );
+
+      // Band label “On Track” should be present in the widget tree.
+      expect(find.text('On Track'), findsOneWidget);
+    });
+
+    testWidgets('semantics label contains readable value and category', (
+      tester,
+    ) async {
+      // Enables semantics testing.
+      final handle = tester.ensureSemantics();
+
+      await tester.pumpWidget(
+        const ProviderScope(
+          child: MaterialApp(
+            home: Scaffold(body: Center(child: MetabolicScoreGauge(mhs: 8))),
+          ),
+        ),
+      );
+
+      // Retrieve the SemanticsNode for the gauge.
+      final finder = find.byType(MetabolicScoreGauge);
+      expect(finder, findsOneWidget);
+      final node = tester.getSemantics(finder);
+
+      // Semantics label should follow the pattern: "Metabolic health score <10 percent, First Gear".
+      expect(node.label, contains('<10'));
+      expect(node.label, contains('First Gear'));
+
+      handle.dispose();
+    });
+  });
+}

--- a/docs/MVP_ROADMAP/1-7 Health Signals/Milestones, Tasks, and Epic Docs/M1.7.4_advanced-metabolic-health-score-gauge.md
+++ b/docs/MVP_ROADMAP/1-7 Health Signals/Milestones, Tasks, and Epic Docs/M1.7.4_advanced-metabolic-health-score-gauge.md
@@ -36,7 +36,7 @@ Momentum Score modifiers.
 | T3      | Implement `mapMhsToCategory()` helper for colour bands                   | 1h       | ✅     |
 | T4      | Build `MetabolicScoreGauge` widget with colour-wheel gauge               | 4h       | ✅     |
 | T5      | Enhance form: BMI auto-calc, A1C toggle, validators & tests              | 2h       | ✅     |
-| T6      | Update docs; raise coverage to ≥ 90 % lines / 100 % branches             | 1h       | 🟡     |
+| T6      | Update docs; raise coverage to ≥ 90 % lines / 100 % branches             | 1h       | ✅     |
 
 ---
 

--- a/docs/MVP_ROADMAP/1-7 Health Signals/epic_1-7_health_signals.md
+++ b/docs/MVP_ROADMAP/1-7 Health Signals/epic_1-7_health_signals.md
@@ -86,19 +86,19 @@ asks relevant question; unit + integration tests ≥ 90 %.
 
 ### M1.7.4 · Advanced Metabolic Health Score & Gauge
 
-| Task | Description                                                              | Hours | Status     |
-| ---- | ------------------------------------------------------------------------ | ----- | ---------- |
-| T1   | Convert coefficient tables to JSON asset & repository loader             | 2h    | ⚪ Planned |
-| T2   | Extend `MetabolicHealthScoreService` for BMI, A1C→FG, percentile mapping | 3h    | ⚪ Planned |
-| T3   | Implement `mapMhsToCategory()` helper for colour bands                   | 1h    | ⚪ Planned |
-| T4   | Build `MetabolicScoreGauge` widget with colour-wheel gauge               | 4h    | ⚪ Planned |
-| T5   | Enhance form: BMI auto-calc, A1C toggle, validators & tests              | 2h    | ⚪ Planned |
-| T6   | Update docs, increase coverage to ≥ 90 % lines / 100 % branches          | 1h    | ⚪ Planned |
+| Task | Description                                                              | Hours | Status      |
+| ---- | ------------------------------------------------------------------------ | ----- | ----------- |
+| T1   | Convert coefficient tables to JSON asset & repository loader             | 2h    | ⚪ Planned  |
+| T2   | Extend `MetabolicHealthScoreService` for BMI, A1C→FG, percentile mapping | 3h    | ⚪ Planned  |
+| T3   | Implement `mapMhsToCategory()` helper for colour bands                   | 1h    | ⚪ Planned  |
+| T4   | Build `MetabolicScoreGauge` widget with colour-wheel gauge               | 4h    | ⚪ Planned  |
+| T5   | Enhance form: BMI auto-calc, A1C toggle, validators & tests              | 2h    | ⚪ Planned  |
+| T6   | Update docs, increase coverage to ≥ 90 % lines / 100 % branches          | 1h    | ✅ Complete |
 
 **Deliverables:** JSON coefficients asset (or Supabase table), upgraded score
 service, category mapper, gauge widget, enhanced form logic, documentation and
-tests.
-**All Equations and Coefficients for Metabolic Health Score in app/data/mhs_data.txt
+tests. **All Equations and Coefficients for Metabolic Health Score in
+app/data/mhs_data.txt
 
 **Acceptance Criteria:**
 


### PR DESCRIPTION
Completes Task T6 of M1.7.4: raises MHS-related coverage ≥ 90% lines / 100% branches, adds edge-case tests, updates docs status flags.