### PR TITLE
Phase 0: Un-skip Flutter tests T0-T1 and add tracker

### DIFF
--- a/app/test/features/onboarding/data/onboarding_repository_test.dart
+++ b/app/test/features/onboarding/data/onboarding_repository_test.dart
@@ -14,6 +14,10 @@ class _MockGoTrueClient extends Mock implements GoTrueClient {}
 
 class _MockStorage extends Mock implements OnboardingDraftStorageService {}
 
+class _MockRpcResult extends Mock implements PostgrestFilterBuilder<dynamic> {}
+
+// The RPC call resolves to a JSON-like map which is ignored by the repository.
+
 class FakeUser extends Fake implements User {
   @override
   String get id => 'test-user';
@@ -43,11 +47,42 @@ void main() {
     });
 
     test('calls Supabase RPC and clears storage on success', () async {
-      // Supabase PostgrestFilterBuilder is difficult to stub; skip detailed behaviour in this unit test.
-    }, skip: true);
+      // Arrange
+      // Stub the Future `then` on the Postgrest builder so that awaiting it resolves.
+      final builder = _MockRpcResult();
+      when(
+        () => builder.then<dynamic>(any(), onError: any(named: 'onError')),
+      ).thenAnswer((invocation) {
+        final onValue =
+            invocation.positionalArguments[0] as dynamic Function(dynamic);
+        return Future.value(<String, dynamic>{}).then(onValue);
+      });
+      when(
+        () => mockClient.rpc('submit_onboarding', params: any(named: 'params')),
+      ).thenAnswer((_) => builder);
+      when(() => mockStorage.clear()).thenAnswer((_) async {});
+
+      // Act
+      await repo.submit(draft: testDraft);
+
+      // Assert
+      verify(
+        () => mockClient.rpc('submit_onboarding', params: any(named: 'params')),
+      ).called(1);
+      verify(() => mockStorage.clear()).called(1);
+    });
 
     test('throws OnboardingSubmissionException on RPC failure', () async {
-      // Skipping due to stub complexity with PostgrestFilterBuilder.
-    }, skip: true);
+      // Arrange
+      when(
+        () => mockClient.rpc('submit_onboarding', params: any(named: 'params')),
+      ).thenThrow(Exception('RPC error'));
+
+      // Act & Assert
+      expect(
+        () => repo.submit(draft: testDraft),
+        throwsA(isA<OnboardingSubmissionException>()),
+      );
+    });
   });
 }

--- a/docs/MVP_ROADMAP/phase_0/ms_0-1_unskip_flutter_tests.md
+++ b/docs/MVP_ROADMAP/phase_0/ms_0-1_unskip_flutter_tests.md
@@ -27,3 +27,17 @@ ticket referencing failure log.
 ---
 
 _Last updated: 2025-07-19_
+
+#### Skipped Tests Tracker
+
+| Skipped Test (file)                       | Description                                                  | Status     |
+| ----------------------------------------- | ------------------------------------------------------------ | ---------- |
+| onboarding_flow_test.dart                 | Onboarding happy-path flow – heavy dependencies              | ⚪ Pending |
+| launch_controller_flow_test.dart          | LaunchController shows AppWrapper when onboarding complete   | ⚪ Pending |
+| onboarding_pages_golden_test.dart         | PreferencesPage golden – flaky baseline                      | ⚪ Pending |
+| medical_history_performance_test.dart     | MedicalHistoryPage performance benchmark (CI unreliable)     | ⚪ Pending |
+| navigation_integration_test.dart          | Achievements navigation scenario – timer conflicts           | ⚪ Pending |
+| adaptive_polling_toggle_test.dart         | AdaptivePollingToggle SharedPreferences interaction          | ⚪ Pending |
+| accessibility_test.dart                   | MomentumCard comprehensive accessibility semantics           | ⚪ Pending |
+| minimal_performance_test.dart             | Minimal performance tests group – platform channel flakiness | ⚪ Pending |
+| momentum_performance_essentials_test.dart | Momentum performance essentials (AI coach benchmarks)        | ⚪ Pending |

--- a/docs/MVP_ROADMAP/phase_0/ms_0-1_unskip_flutter_tests.md
+++ b/docs/MVP_ROADMAP/phase_0/ms_0-1_unskip_flutter_tests.md
@@ -7,8 +7,8 @@ failures, and raise CI coverage gate to 45 %.
 
 | Task | Description                                                      | Est    | Status |
 | ---- | ---------------------------------------------------------------- | ------ | ------ |
-| T0   | List all lines containing `skip:` via grep; paste into checklist | 0.5 h  | ⬜     |
-| T1   | Remove `skip:` from test group #1; fix failures                  | 1 h    | ⬜     |
+| T0   | List all lines containing `skip:` via grep; paste into checklist | 0.5 h  | ✅     |
+| T1   | Remove `skip:` from test group #1; fix failures                  | 1 h    | ✅     |
 | T2   | Repeat for remaining tests (#2-#12)                              | 3 h    | ⬜     |
 | T3   | Update or regenerate golden images if diff errors arise          | 1 h    | ⬜     |
 | T4   | Run `make ci-fast` locally until green                           | —      | ⬜     |


### PR DESCRIPTION
### Summary\nThis PR kicks off Mini-Sprint 0-1 by completing tasks T0 and T1.\n\n✔️ Removed `skip:` flags from **OnboardingRepository** unit tests and implemented real stubs so they pass.\n✔️ Updated checklist in *ms_0-1_unskip_flutter_tests.md* (T0, T1 marked complete).\n✔️ Added **Skipped Tests Tracker** table listing remaining skipped tests with ⚪ Pending status for incremental fixes.\n\nAll Flutter tests pass locally; CI should remain green because other problematic tests are still skipped.\n\nPart of Phase 0 · Stability & Hygiene plan.