### PR TITLE
Component size refactor P4-B: analytics services

### DIFF
--- a/app/lib/features/today_feed/data/datasources/today_feed_analytics_remote_datasource.dart
+++ b/app/lib/features/today_feed/data/datasources/today_feed_analytics_remote_datasource.dart
@@ -1,0 +1,19 @@
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+/// Remote data-source for interaction analytics & reading sessions.
+/// Encapsulates all Supabase writes so services remain storage-agnostic.
+class TodayFeedAnalyticsRemoteDataSource {
+  TodayFeedAnalyticsRemoteDataSource() : _supabase = Supabase.instance.client;
+
+  final SupabaseClient _supabase;
+
+  /// Inserts a user interaction analytics event.
+  Future<void> insertInteractionEvent(Map<String, dynamic> data) async {
+    await _supabase.from('today_feed_analytics_events').insert(data);
+  }
+
+  /// Inserts a reading-session row.
+  Future<void> insertReadingSession(Map<String, dynamic> data) async {
+    await _supabase.from('today_feed_reading_sessions').insert(data);
+  }
+}

--- a/app/lib/features/today_feed/data/models/dashboard_models.dart
+++ b/app/lib/features/today_feed/data/models/dashboard_models.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import '../services/session_duration_tracking_service.dart';
+import '../../domain/models/reading_session_models.dart';
 
 /// Dashboard data models for Today Feed analytics
 ///

--- a/app/lib/features/today_feed/domain/models/interaction_analytics_models.dart
+++ b/app/lib/features/today_feed/domain/models/interaction_analytics_models.dart
@@ -1,0 +1,169 @@
+// Analytics data models extracted from today_feed_interaction_analytics_service.dart
+
+class UserInteractionAnalytics {
+  final String userId;
+  final int analysisPeriodDays;
+  final int totalInteractions;
+  final int uniqueContentPieces;
+  final double averageSessionDuration;
+  final String engagementLevel;
+  final double engagementRate;
+  final Map<String, double> topicPreferences;
+  final Map<String, dynamic> engagementPatterns;
+  final int consecutiveDaysEngaged;
+  final DateTime? lastInteractionDate;
+
+  const UserInteractionAnalytics({
+    required this.userId,
+    required this.analysisPeriodDays,
+    required this.totalInteractions,
+    required this.uniqueContentPieces,
+    required this.averageSessionDuration,
+    required this.engagementLevel,
+    required this.engagementRate,
+    required this.topicPreferences,
+    required this.engagementPatterns,
+    required this.consecutiveDaysEngaged,
+    this.lastInteractionDate,
+  });
+
+  factory UserInteractionAnalytics.empty(String userId) {
+    return UserInteractionAnalytics(
+      userId: userId,
+      analysisPeriodDays: 0,
+      totalInteractions: 0,
+      uniqueContentPieces: 0,
+      averageSessionDuration: 0.0,
+      engagementLevel: 'low',
+      engagementRate: 0.0,
+      topicPreferences: const {},
+      engagementPatterns: const {},
+      consecutiveDaysEngaged: 0,
+    );
+  }
+}
+
+class ContentPerformanceAnalytics {
+  final int contentId;
+  final int totalViews;
+  final int totalClicks;
+  final int uniqueViewers;
+  final double averageSessionDuration;
+  final double engagementRate;
+  final double performanceScore;
+  final Map<String, int> interactionBreakdown;
+
+  const ContentPerformanceAnalytics({
+    required this.contentId,
+    required this.totalViews,
+    required this.totalClicks,
+    required this.uniqueViewers,
+    required this.averageSessionDuration,
+    required this.engagementRate,
+    required this.performanceScore,
+    required this.interactionBreakdown,
+  });
+
+  factory ContentPerformanceAnalytics.empty(int contentId) {
+    return ContentPerformanceAnalytics(
+      contentId: contentId,
+      totalViews: 0,
+      totalClicks: 0,
+      uniqueViewers: 0,
+      averageSessionDuration: 0.0,
+      engagementRate: 0.0,
+      performanceScore: 0.0,
+      interactionBreakdown: const {},
+    );
+  }
+}
+
+class EngagementTrendsAnalytics {
+  final List<DailyEngagementData> dailyData;
+  final String trendDirection;
+  final double averageEngagementRate;
+  final DateTime? peakEngagementDate;
+
+  const EngagementTrendsAnalytics({
+    required this.dailyData,
+    required this.trendDirection,
+    required this.averageEngagementRate,
+    this.peakEngagementDate,
+  });
+
+  factory EngagementTrendsAnalytics.empty() {
+    return const EngagementTrendsAnalytics(
+      dailyData: [],
+      trendDirection: 'stable',
+      averageEngagementRate: 0.0,
+    );
+  }
+}
+
+class DailyEngagementData {
+  final DateTime date;
+  final int totalViews;
+  final int uniqueUsers;
+  final double engagementRate;
+  final double averageSessionDuration;
+
+  const DailyEngagementData({
+    required this.date,
+    required this.totalViews,
+    required this.uniqueUsers,
+    required this.engagementRate,
+    required this.averageSessionDuration,
+  });
+}
+
+class TopicPerformanceAnalytics {
+  final Map<String, double> topicEngagementRates;
+  final Map<String, int> topicViewCounts;
+  final String mostEngagingTopic;
+  final String leastEngagingTopic;
+
+  const TopicPerformanceAnalytics({
+    required this.topicEngagementRates,
+    required this.topicViewCounts,
+    required this.mostEngagingTopic,
+    required this.leastEngagingTopic,
+  });
+
+  factory TopicPerformanceAnalytics.empty() {
+    return const TopicPerformanceAnalytics(
+      topicEngagementRates: {},
+      topicViewCounts: {},
+      mostEngagingTopic: '',
+      leastEngagingTopic: '',
+    );
+  }
+}
+
+class RealTimeEngagementMetrics {
+  final int currentActiveUsers;
+  final int todayTotalViews;
+  final int todayUniqueUsers;
+  final double todayEngagementRate;
+  final int todayMomentumPointsAwarded;
+  final DateTime lastUpdated;
+
+  const RealTimeEngagementMetrics({
+    required this.currentActiveUsers,
+    required this.todayTotalViews,
+    required this.todayUniqueUsers,
+    required this.todayEngagementRate,
+    required this.todayMomentumPointsAwarded,
+    required this.lastUpdated,
+  });
+
+  factory RealTimeEngagementMetrics.empty() {
+    return RealTimeEngagementMetrics(
+      currentActiveUsers: 0,
+      todayTotalViews: 0,
+      todayUniqueUsers: 0,
+      todayEngagementRate: 0.0,
+      todayMomentumPointsAwarded: 0,
+      lastUpdated: DateTime.now(),
+    );
+  }
+}

--- a/app/lib/features/today_feed/domain/models/reading_session_models.dart
+++ b/app/lib/features/today_feed/domain/models/reading_session_models.dart
@@ -1,0 +1,195 @@
+import 'dart:math' as math;
+import 'package:flutter/foundation.dart';
+import '../../../../core/services/version_service.dart';
+import 'today_feed_content.dart';
+
+/// Session quality metrics for engagement analysis
+enum SessionQuality {
+  brief('brief'),
+  moderate('moderate'),
+  engaged('engaged'),
+  deep('deep');
+
+  const SessionQuality(this.value);
+  final String value;
+
+  static SessionQuality fromDuration(Duration duration) {
+    if (duration < const Duration(seconds: 30)) {
+      return SessionQuality.brief;
+    } else if (duration < const Duration(minutes: 2)) {
+      return SessionQuality.moderate;
+    } else if (duration < const Duration(minutes: 5)) {
+      return SessionQuality.engaged;
+    } else {
+      return SessionQuality.deep;
+    }
+  }
+}
+
+/// Reading session data model for analytics
+class ReadingSession {
+  final String sessionId;
+  final String userId;
+  final int contentId;
+  final DateTime startTime;
+  final DateTime endTime;
+  final Duration duration;
+  final SessionQuality quality;
+  final int samplesCount;
+  final double engagementScore;
+  final Map<String, dynamic> metadata;
+
+  const ReadingSession({
+    required this.sessionId,
+    required this.userId,
+    required this.contentId,
+    required this.startTime,
+    required this.endTime,
+    required this.duration,
+    required this.quality,
+    required this.samplesCount,
+    required this.engagementScore,
+    required this.metadata,
+  });
+
+  factory ReadingSession.fromTrackingData({
+    required String sessionId,
+    required String userId,
+    required int contentId,
+    required DateTime startTime,
+    required DateTime endTime,
+    required List<DateTime> activitySamples,
+    required TodayFeedContent content,
+    Map<String, dynamic>? additionalMetadata,
+  }) {
+    final duration = endTime.difference(startTime);
+    final quality = SessionQuality.fromDuration(duration);
+    final engagementScore = _calculateEngagementScore(
+      duration,
+      content.estimatedReadingMinutes,
+      activitySamples.length,
+    );
+
+    return ReadingSession(
+      sessionId: sessionId,
+      userId: userId,
+      contentId: contentId,
+      startTime: startTime,
+      endTime: endTime,
+      duration: duration,
+      quality: quality,
+      samplesCount: activitySamples.length,
+      engagementScore: engagementScore,
+      metadata: {
+        'content_title': content.title,
+        'content_category': content.topicCategory.value,
+        'estimated_reading_minutes': content.estimatedReadingMinutes,
+        'ai_confidence_score': content.aiConfidenceScore,
+        'platform': defaultTargetPlatform.name,
+        'app_version': VersionService.appVersion,
+        ...?additionalMetadata,
+      },
+    );
+  }
+
+  static double _calculateEngagementScore(
+    Duration actualDuration,
+    int estimatedMinutes,
+    int samplesCount,
+  ) {
+    if (estimatedMinutes <= 0) return 0.0;
+
+    final estimatedDuration = Duration(minutes: estimatedMinutes);
+    final baseScore = math.min(
+      actualDuration.inMilliseconds / estimatedDuration.inMilliseconds,
+      2.0,
+    );
+
+    final samplingQuality = math.min(samplesCount / 10.0, 1.0);
+
+    return (baseScore * samplingQuality).clamp(0.0, 2.0);
+  }
+
+  Map<String, dynamic> toJson() => {
+    'session_id': sessionId,
+    'user_id': userId,
+    'content_id': contentId,
+    'start_time': startTime.toIso8601String(),
+    'end_time': endTime.toIso8601String(),
+    'duration_seconds': duration.inSeconds,
+    'session_quality': quality.value,
+    'samples_count': samplesCount,
+    'engagement_score': engagementScore,
+    'metadata': metadata,
+  };
+
+  factory ReadingSession.fromJson(Map<String, dynamic> json) => ReadingSession(
+    sessionId: json['session_id'] as String,
+    userId: json['user_id'] as String,
+    contentId: json['content_id'] as int,
+    startTime: DateTime.parse(json['start_time'] as String),
+    endTime: DateTime.parse(json['end_time'] as String),
+    duration: Duration(seconds: json['duration_seconds'] as int),
+    quality: SessionQuality.values.firstWhere(
+      (q) => q.value == json['session_quality'],
+      orElse: () => SessionQuality.brief,
+    ),
+    samplesCount: json['samples_count'] as int,
+    engagementScore: (json['engagement_score'] as num).toDouble(),
+    metadata: json['metadata'] as Map<String, dynamic>,
+  );
+
+  @override
+  int get hashCode => Object.hash(sessionId, userId, contentId);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is ReadingSession &&
+        other.sessionId == sessionId &&
+        other.userId == userId &&
+        other.contentId == contentId;
+  }
+
+  @override
+  String toString() =>
+      'ReadingSession(id: $sessionId, duration: ${duration.inSeconds}s, quality: ${quality.value})';
+}
+
+/// Aggregated analytics across sessions
+class SessionAnalytics {
+  final int totalSessions;
+  final Duration totalReadingTime;
+  final Duration averageSessionDuration;
+  final double averageEngagementScore;
+  final Map<SessionQuality, int> qualityDistribution;
+  final Map<String, double> topicEngagement;
+  final DateTime? lastSessionTime;
+  final int consecutiveDaysWithSessions;
+
+  const SessionAnalytics({
+    required this.totalSessions,
+    required this.totalReadingTime,
+    required this.averageSessionDuration,
+    required this.averageEngagementScore,
+    required this.qualityDistribution,
+    required this.topicEngagement,
+    this.lastSessionTime,
+    required this.consecutiveDaysWithSessions,
+  });
+
+  factory SessionAnalytics.empty() {
+    return const SessionAnalytics(
+      totalSessions: 0,
+      totalReadingTime: Duration.zero,
+      averageSessionDuration: Duration.zero,
+      averageEngagementScore: 0.0,
+      qualityDistribution: {},
+      topicEngagement: {},
+      consecutiveDaysWithSessions: 0,
+    );
+  }
+
+  double get readingEfficiency =>
+      totalSessions == 0 ? 0.0 : averageEngagementScore.clamp(0.0, 1.0);
+}

--- a/docs/MVP_ROADMAP/phase_0/ms_0-3_component_size_tech_plan.md
+++ b/docs/MVP_ROADMAP/phase_0/ms_0-3_component_size_tech_plan.md
@@ -118,7 +118,7 @@ If the enforced step blocks PRs unexpectedly:
 | ID   | Key File(s)                                                                    | Key Refactor Action                         | Est | Status |
 | ---- | ------------------------------------------------------------------------------ | ------------------------------------------- | --- | ------ |
 | P4-A | `notification_core_service.dart`                                               | Extract token & permission helpers          | 2h  | ✅     |
-| P4-B | `interaction_analytics_service.dart`, `session_duration_tracking_service.dart` | Split analytics helpers; isolate DB writes  | 2h  | ⬜     |
+| P4-B | `interaction_analytics_service.dart`, `session_duration_tracking_service.dart` | Split analytics helpers; isolate DB writes  | 2h  | ✅     |
 | P4-C | `momentum_point_feedback_widget.dart`                                          | Split into animation/header/body            | 1h  | ⬜     |
 | P4-D | `today_feed_interactions.dart`                                                 | Modularize into like/share/bookmark widgets | 1h  | ⬜     |
 | P4-E | `error_state_widget.dart`                                                      | Extract error card + retry CTA              | 1h  | ⬜     |


### PR DESCRIPTION
This PR implements P4-B of the component-size tech plan.\n\n• Extracts analytics/reading-session models into domain layer\n• Adds TodayFeedAnalyticsRemoteDataSource to centralise Supabase writes\n• Refactors interaction & session analytics services to use data-source\n• Updates dashboard models import\n• Marks P4-B ✅ in tech plan\n\nCI impact: Dart/Flutter only; no Deno, Python or migrations touched. Size script passes in warning mode.\n