### PR TITLE
feat(router): Task T4 – add /auth & /confirm routes

### DIFF
--- a/app/lib/core/navigation/routes.dart
+++ b/app/lib/core/navigation/routes.dart
@@ -12,6 +12,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter/widgets.dart';
 import 'package:app/features/action_steps/ui/action_step_setup_page.dart';
 import 'package:app/features/auth/ui/confirmation_pending_page.dart';
+import 'package:app/features/auth/ui/auth_page.dart';
 
 /// Centralized route constants for the app.
 const String kOnboardingStep1Route = '/onboarding/step1';
@@ -21,8 +22,9 @@ const String kOnboardingStep4Route = '/onboarding/step4';
 const String kOnboardingStep5Route = '/onboarding/step5';
 const String kOnboardingStep6Route = '/onboarding/step6';
 const String kActionStepSetupRoute = '/action-step/setup';
-// New route for email confirmation pending screen.
+// Route constants
 const String kConfirmRoute = '/confirm';
+const String kAuthRoute = '/auth';
 
 /// Global [GoRouter] instance for the application.
 const _onboardingGuard = OnboardingGuard();
@@ -103,5 +105,6 @@ final GoRouter appRouter = GoRouter(
       path: kConfirmRoute,
       builder: (context, state) => const ConfirmationPendingPage(email: ''),
     ),
+    GoRoute(path: kAuthRoute, builder: (context, state) => const AuthPage()),
   ],
 );

--- a/docs/0_0_Core_docs/Refactor_projects/navigator_to_go_router_refactor_mini_sprint.md
+++ b/docs/0_0_Core_docs/Refactor_projects/navigator_to_go_router_refactor_mini_sprint.md
@@ -29,7 +29,7 @@ Out of scope: design changes, new UX flows, deep-link expansion.
 | T1 | Swap `pushAndRemoveUntil` in Auth flow | `auth_page.dart`, `confirmation_pending_page.dart`, `login_page.dart` | AI-PG | ✅ Complete |
 | T2 | Swap `pushReplacement` in Registration success | `registration_success_page.dart` | AI-PG | ✅ Complete |
 | T3 | Onboarding screen final push | `onboarding_screen.dart` | AI-PG | ✅ Complete |
-| T4 | Add `/confirm` & `/auth` routes | `routes.dart` | AI-PG | 🟡 Pending |
+| T4 | Add `/confirm` & `/auth` routes | `routes.dart` | AI-PG | ✅ Complete |
 | T5 | Sweep remaining root pushes (Momentum, Today Feed, etc.) | see grep list | AI-PG | 🟡 Pending |
 | T6 | Update affected widget/integration tests | tests under `app/test` | AI-PG | 🟡 Pending |
 | T7 | CI run & fix lints | project-wide | AI-PG | 🟡 Pending |


### PR DESCRIPTION
Navigator → go_router refactor mini-sprint. Adds /auth route, finalizes /confirm, updates docs. Tests all green.