### PR TITLE
refactor: Navigator -> go_router sweep (T5)

### DIFF
--- a/app/lib/core/debug/live_vitals_runner.dart
+++ b/app/lib/core/debug/live_vitals_runner.dart
@@ -6,8 +6,8 @@ library;
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-
-import '../../features/wearable/ui/live_vitals_developer_screen.dart';
+import 'package:go_router/go_router.dart';
+import 'package:app/core/navigation/routes.dart';
 
 /// Open the Live Vitals developer screen for validation
 ///
@@ -26,12 +26,7 @@ void openLiveVitalsScreen(BuildContext context) {
 
   debugPrint('🔴 Opening Live Vitals Developer Screen');
 
-  Navigator.of(context).push(
-    MaterialPageRoute(
-      builder: (context) => const LiveVitalsDeveloperScreen(),
-      settings: const RouteSettings(name: '/debug/live-vitals'),
-    ),
-  );
+  context.push(kLiveVitalsDebugRoute);
 }
 
 /// Check if Live Vitals screen is available

--- a/app/lib/core/navigation/routes.dart
+++ b/app/lib/core/navigation/routes.dart
@@ -13,6 +13,15 @@ import 'package:flutter/widgets.dart';
 import 'package:app/features/action_steps/ui/action_step_setup_page.dart';
 import 'package:app/features/auth/ui/confirmation_pending_page.dart';
 import 'package:app/features/auth/ui/auth_page.dart';
+import 'package:app/features/momentum/presentation/screens/notification_settings_screen.dart';
+import 'package:app/features/momentum/presentation/screens/profile_settings_screen.dart';
+import 'package:app/features/gamification/ui/achievements_screen.dart';
+import 'package:app/features/gamification/ui/progress_dashboard.dart';
+import 'package:app/features/today_feed/presentation/screens/today_feed_article_screen.dart';
+import 'package:app/features/today_feed/domain/models/today_feed_content.dart';
+import 'package:app/features/ai_coach/ui/coach_chat_screen.dart';
+import 'package:app/features/wearable/ui/live_vitals_developer_screen.dart';
+import 'package:app/features/auth/ui/password_reset_page.dart';
 
 /// Centralized route constants for the app.
 const String kOnboardingStep1Route = '/onboarding/step1';
@@ -25,6 +34,17 @@ const String kActionStepSetupRoute = '/action-step/setup';
 // Route constants
 const String kConfirmRoute = '/confirm';
 const String kAuthRoute = '/auth';
+
+// NEW ROUTE CONSTANTS
+const String kNotificationsRoute = '/notifications';
+const String kProfileSettingsRoute = '/profile-settings';
+const String kAchievementsRoute = '/achievements';
+const String kProgressDashboardRoute = '/progress-dashboard';
+const String kTodayFeedArticleRoute = '/today-feed/article';
+const String kCoachChatRoute = '/coach-chat';
+const String kPasswordResetRoute = '/password-reset';
+const String kLiveVitalsDebugRoute = '/debug/live-vitals';
+const String kLaunchRoute = '/launch';
 
 /// Global [GoRouter] instance for the application.
 const _onboardingGuard = OnboardingGuard();
@@ -106,5 +126,53 @@ final GoRouter appRouter = GoRouter(
       builder: (context, state) => const ConfirmationPendingPage(email: ''),
     ),
     GoRoute(path: kAuthRoute, builder: (context, state) => const AuthPage()),
+
+    // NEW ROUTES
+    GoRoute(
+      path: kNotificationsRoute,
+      builder: (context, state) => const NotificationSettingsScreen(),
+    ),
+    GoRoute(
+      path: kProfileSettingsRoute,
+      builder: (context, state) => const ProfileSettingsScreen(),
+    ),
+    GoRoute(
+      path: kAchievementsRoute,
+      builder: (context, state) => const AchievementsScreen(),
+    ),
+    GoRoute(
+      path: kProgressDashboardRoute,
+      builder: (context, state) => const ProgressDashboard(),
+    ),
+    GoRoute(
+      path: kTodayFeedArticleRoute,
+      builder: (context, state) {
+        final content = state.extra as TodayFeedContent;
+        return TodayFeedArticleScreen(content: content);
+      },
+    ),
+    GoRoute(
+      path: kCoachChatRoute,
+      builder: (context, state) {
+        final extra = state.extra as Map<String, dynamic>?;
+        return CoachChatScreen(
+          articleId: extra?['articleId'],
+          articleSummary: extra?['articleSummary'],
+          articleTitle: extra?['articleTitle'],
+          showBackButton: true,
+        );
+      },
+    ),
+    GoRoute(
+      path: kLiveVitalsDebugRoute,
+      builder: (context, state) => const LiveVitalsDeveloperScreen(),
+    ),
+    GoRoute(
+      path: kPasswordResetRoute,
+      builder: (context, state) {
+        final token = state.extra as String;
+        return PasswordResetPage(accessToken: token);
+      },
+    ),
   ],
 );

--- a/app/lib/features/gamification/ui/achievements_screen.dart
+++ b/app/lib/features/gamification/ui/achievements_screen.dart
@@ -1,11 +1,13 @@
 import 'package:flutter/material.dart' hide Badge;
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import 'package:go_router/go_router.dart';
+import 'package:app/core/navigation/routes.dart';
+
 import '../../../core/theme/app_theme.dart';
 import '../../../core/services/responsive_service.dart';
 import '../providers/gamification_providers.dart';
 import '../services/share_helper.dart';
-import 'progress_dashboard.dart';
 
 // Extracted widgets
 import 'achievements/achievements_header.dart';
@@ -34,11 +36,7 @@ class AchievementsScreen extends ConsumerWidget {
           IconButton(
             icon: const Icon(Icons.bar_chart),
             onPressed: () {
-              Navigator.of(context).push(
-                MaterialPageRoute(
-                  builder: (context) => const ProgressDashboard(),
-                ),
-              );
+              context.push(kProgressDashboardRoute);
             },
             tooltip: 'View Progress Dashboard',
           ),

--- a/app/lib/features/momentum/presentation/screens/momentum_screen.dart
+++ b/app/lib/features/momentum/presentation/screens/momentum_screen.dart
@@ -16,18 +16,15 @@ import '../widgets/skeleton_widgets.dart';
 import '../widgets/loading_indicator.dart';
 import '../widgets/error_widgets.dart';
 import '../../../../core/services/error_handling_service.dart';
-import 'notification_settings_screen.dart';
-import 'profile_settings_screen.dart';
+
+// Routing
+import 'package:go_router/go_router.dart';
+import 'package:app/core/navigation/routes.dart';
 
 // Today Feed imports
 import '../../../today_feed/presentation/widgets/today_feed_tile.dart';
 import '../providers/today_feed_provider.dart';
-import '../../../today_feed/presentation/screens/today_feed_article_screen.dart';
 
-// Gamification imports
-import '../../../gamification/ui/achievements_screen.dart';
-
-// Coach Chat imports
 /// Main momentum meter screen
 /// Displays the user's current momentum state and provides quick actions
 class MomentumScreen extends ConsumerWidget {
@@ -49,11 +46,7 @@ class MomentumScreen extends ConsumerWidget {
             child: IconButton(
               icon: const Icon(Icons.notifications_outlined),
               onPressed: () {
-                Navigator.of(context).push(
-                  MaterialPageRoute(
-                    builder: (context) => const NotificationSettingsScreen(),
-                  ),
-                );
+                context.push(kNotificationsRoute);
               },
             ),
           ),
@@ -64,11 +57,7 @@ class MomentumScreen extends ConsumerWidget {
             child: IconButton(
               icon: const Icon(Icons.person_outline),
               onPressed: () {
-                Navigator.of(context).push(
-                  MaterialPageRoute(
-                    builder: (context) => const ProfileSettingsScreen(),
-                  ),
-                );
+                context.push(kProfileSettingsRoute);
               },
             ),
           ),
@@ -164,11 +153,7 @@ class _MomentumContent extends ConsumerWidget {
               final content = todayFeedState.content;
 
               if (content != null && context.mounted) {
-                await Navigator.of(context).push(
-                  MaterialPageRoute(
-                    builder: (_) => TodayFeedArticleScreen(content: content),
-                  ),
-                );
+                await context.push(kTodayFeedArticleRoute, extra: content);
               } else if (context.mounted) {
                 ScaffoldMessenger.of(context).showSnackBar(
                   const SnackBar(
@@ -241,11 +226,7 @@ class _MomentumContent extends ConsumerWidget {
               onAchievementsTap: () {
                 // Navigate to achievements screen
                 context.announceToScreenReader('Navigating to achievements');
-                Navigator.of(context).push(
-                  MaterialPageRoute(
-                    builder: (context) => const AchievementsScreen(),
-                  ),
-                );
+                context.push(kAchievementsRoute);
               },
             )
           else

--- a/app/lib/features/momentum/presentation/screens/profile_settings_screen.dart
+++ b/app/lib/features/momentum/presentation/screens/profile_settings_screen.dart
@@ -9,7 +9,8 @@ import '../widgets/adaptive_polling_toggle.dart';
 import '../widgets/health_permission_toggle.dart';
 import '../../../../core/mixins/permission_auto_refresh_mixin.dart';
 import 'package:app/features/settings/ui/mfa_toggle_tile.dart';
-import '../../../../core/widgets/launch_controller.dart';
+import 'package:go_router/go_router.dart';
+import 'package:app/core/navigation/routes.dart';
 import '../../../../core/providers/auth_provider.dart';
 
 /// Screen for managing user profile and app settings
@@ -322,12 +323,7 @@ class _ProfileSettingsScreenState extends ConsumerState<ProfileSettingsScreen>
                     onTap: () async {
                       await ref.read(authNotifierProvider.notifier).signOut();
                       if (context.mounted) {
-                        Navigator.of(context).pushAndRemoveUntil(
-                          MaterialPageRoute(
-                            builder: (_) => const LaunchController(),
-                          ),
-                          (route) => false,
-                        );
+                        context.go(kLaunchRoute);
                       }
                     },
                   ),

--- a/app/lib/features/today_feed/presentation/widgets/today_feed_tile.dart
+++ b/app/lib/features/today_feed/presentation/widgets/today_feed_tile.dart
@@ -9,7 +9,8 @@ import 'states/error_state_widget.dart';
 import 'states/loaded_state_widget.dart';
 import 'offline/offline_state_widget.dart';
 import 'offline/fallback_state_widget.dart';
-import '../../../ai_coach/ui/coach_chat_screen.dart';
+import 'package:go_router/go_router.dart';
+import 'package:app/core/navigation/routes.dart';
 
 /// Callback types for Today Feed tile interactions
 typedef TodayFeedCallback = void Function();
@@ -205,16 +206,13 @@ class _TodayFeedTileState extends State<TodayFeedTile>
         onLongPress: () {
           final content = widget.state.content;
 
-          Navigator.of(context).push(
-            MaterialPageRoute(
-              builder:
-                  (_) => CoachChatScreen(
-                    articleId: content?.id?.toString(),
-                    articleTitle: content?.title,
-                    articleSummary: _buildArticleSummary(content),
-                    showBackButton: true,
-                  ),
-            ),
+          context.push(
+            kCoachChatRoute,
+            extra: {
+              'articleId': content?.id?.toString(),
+              'articleSummary': _buildArticleSummary(content),
+              'articleTitle': content?.title,
+            },
           );
         },
         child: Semantics(

--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -11,7 +11,7 @@ import 'core/providers/supabase_provider.dart';
 import 'features/momentum/presentation/screens/momentum_screen.dart';
 import 'features/ai_coach/ui/coach_chat_screen.dart';
 import 'core/utils/deep_link_service.dart';
-import 'features/auth/ui/password_reset_page.dart';
+import 'package:go_router/go_router.dart';
 import 'features/momentum/presentation/screens/profile_settings_screen.dart';
 import 'features/gamification/ui/rewards_navigator.dart';
 import 'core/notifications/domain/services/notification_preferences_service.dart';
@@ -223,11 +223,7 @@ class _AppWrapperState extends ConsumerState<AppWrapper>
     if (DeepLinkService.isPasswordReset(uri)) {
       final token = DeepLinkService.extractAccessToken(uri);
       if (token != null) {
-        Navigator.of(context).push(
-          MaterialPageRoute(
-            builder: (_) => PasswordResetPage(accessToken: token),
-          ),
-        );
+        context.push(kPasswordResetRoute, extra: token);
       }
     }
   }

--- a/app/test/features/gamification/ui/navigation_integration_test.dart
+++ b/app/test/features/gamification/ui/navigation_integration_test.dart
@@ -6,6 +6,9 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'package:app/features/gamification/ui/achievements_screen.dart';
 import 'package:app/features/gamification/providers/gamification_providers.dart';
 import 'package:app/features/gamification/models/badge.dart';
+import 'package:go_router/go_router.dart';
+import 'package:app/core/navigation/routes.dart';
+import 'package:app/features/gamification/ui/progress_dashboard.dart';
 
 void main() {
   group('Gamification Navigation Integration', () {
@@ -24,11 +27,19 @@ void main() {
     testWidgets('AchievementsScreen renders correctly', (
       WidgetTester tester,
     ) async {
-      // Build the AchievementsScreen directly with provider overrides
+      final router = GoRouter(
+        routes: [
+          GoRoute(path: '/', builder: (_, __) => const AchievementsScreen()),
+          GoRoute(
+            path: kProgressDashboardRoute,
+            builder: (_, __) => const ProgressDashboard(),
+          ),
+        ],
+      );
+
       await tester.pumpWidget(
         ProviderScope(
           overrides: [
-            // Override challengeProvider to avoid timer issues in tests
             challengeProvider.overrideWith(
               (ref) => Stream.value(<Challenge>[]),
             ),
@@ -37,7 +48,7 @@ void main() {
             currentStreakProvider.overrideWith((ref) async => 0),
             totalPointsProvider.overrideWith((ref) async => 0),
           ],
-          child: const MaterialApp(home: AchievementsScreen()),
+          child: MaterialApp.router(routerConfig: router),
         ),
       );
 
@@ -56,11 +67,19 @@ void main() {
     testWidgets('ProgressDashboard can be accessed from AchievementsScreen', (
       WidgetTester tester,
     ) async {
-      // Build the AchievementsScreen with provider overrides
+      final router = GoRouter(
+        routes: [
+          GoRoute(path: '/', builder: (_, __) => const AchievementsScreen()),
+          GoRoute(
+            path: kProgressDashboardRoute,
+            builder: (_, __) => const ProgressDashboard(),
+          ),
+        ],
+      );
+
       await tester.pumpWidget(
         ProviderScope(
           overrides: [
-            // Override challengeProvider to avoid timer issues in tests
             challengeProvider.overrideWith(
               (ref) => Stream.value(<Challenge>[]),
             ),
@@ -69,7 +88,7 @@ void main() {
             currentStreakProvider.overrideWith((ref) async => 0),
             totalPointsProvider.overrideWith((ref) async => 0),
           ],
-          child: const MaterialApp(home: AchievementsScreen()),
+          child: MaterialApp.router(routerConfig: router),
         ),
       );
 


### PR DESCRIPTION
Completes Task T5 of Navigator → go_router Mini-Sprint.\n\nHighlights:\n* Added new routes + constants in core/navigation.\n* Replaced remaining root-level Navigator pushes with go_router helpers across Momentum, Today Feed, Achievements, Profile, etc.\n* Updated affected tests; entire flutter test suite passes locally.\n\nPart of docs/0_0_Core_docs/Refactor_projects/navigator_to_go_router_refactor_mini_sprint.md