### PR TITLE
fix(router): deep-link filtering & startup crash fixes

### DIFF
--- a/app/lib/core/navigation/filtering_route_information_provider.dart
+++ b/app/lib/core/navigation/filtering_route_information_provider.dart
@@ -1,0 +1,69 @@
+import 'package:flutter/widgets.dart';
+
+/// RouteInformationProvider that ignores non-web (http/https) custom-scheme
+/// links so that GoRouter doesn’t throw `Bad state: Origin is only applicable
+/// to schemes http and https`. This is a lightweight guard around the default
+/// [PlatformRouteInformationProvider].
+///
+/// TODO(ai-router): Revisit once go_router supports custom-scheme parsing or
+/// when deep-link handling is migrated to a dedicated handler. For now this
+/// is adequate to suppress the exception without side-effects.
+class FilteringRouteInformationProvider extends RouteInformationProvider {
+  FilteringRouteInformationProvider(this._inner) {
+    _value = _inner.value;
+    _inner.addListener(_handleInner);
+  }
+
+  final RouteInformationProvider _inner;
+  late RouteInformation _value;
+
+  final List<VoidCallback> _listeners = [];
+
+  void _notify() {
+    for (final l in List<VoidCallback>.from(_listeners)) {
+      l();
+    }
+  }
+
+  void _handleInner() {
+    final info = _inner.value;
+    if (_shouldForward(info)) {
+      _value = info;
+      _notify();
+    }
+  }
+
+  bool _shouldForward(RouteInformation? info) {
+    final uri = info?.uri ?? Uri();
+    // Allow empty scheme (in-app routes) or web URLs handled by go_router.
+    return uri.scheme.isEmpty || uri.scheme == 'http' || uri.scheme == 'https';
+  }
+
+  @override
+  RouteInformation get value => _value;
+
+  @override
+  void routerReportsNewRouteInformation(
+    RouteInformation routeInformation, {
+    RouteInformationReportingType type = RouteInformationReportingType.none,
+  }) {
+    // Forward programmatic route updates back to the wrapped provider so the
+    // platform (e.g., Web) receives them.
+    _inner.routerReportsNewRouteInformation(routeInformation, type: type);
+  }
+
+  @override
+  void addListener(VoidCallback listener) {
+    _listeners.add(listener);
+  }
+
+  @override
+  void removeListener(VoidCallback listener) {
+    _listeners.remove(listener);
+  }
+
+  void dispose() {
+    _inner.removeListener(_handleInner);
+    _listeners.clear();
+  }
+}

--- a/app/lib/core/navigation/routes.dart
+++ b/app/lib/core/navigation/routes.dart
@@ -123,7 +123,12 @@ final GoRouter appRouter = GoRouter(
     ),
     GoRoute(
       path: kConfirmRoute,
-      builder: (context, state) => const ConfirmationPendingPage(email: ''),
+      builder: (context, state) {
+        // Email can be passed via `state.extra` when navigating with
+        // `context.go(kConfirmRoute, extra: email)`.
+        final email = state.extra as String? ?? '';
+        return ConfirmationPendingPage(email: email);
+      },
     ),
     GoRoute(path: kAuthRoute, builder: (context, state) => const AuthPage()),
 

--- a/app/lib/features/auth/ui/auth_page.dart
+++ b/app/lib/features/auth/ui/auth_page.dart
@@ -6,7 +6,7 @@ import '../../../core/providers/auth_provider.dart';
 import '../../../core/utils/auth_error_mapper.dart';
 import 'package:go_router/go_router.dart';
 import 'login_page.dart';
-import 'confirmation_pending_page.dart';
+import '../../../core/navigation/routes.dart';
 import '../../../core/ui/widgets/bee_text_field.dart';
 import '../../../core/validators/auth_validators.dart';
 
@@ -72,12 +72,9 @@ class _AuthPageState extends ConsumerState<AuthPage> {
       } else if (next.hasValue && next.value == null && _submitted) {
         // No session yet → show confirmation pending
         final email = _emailCtrl.text.trim();
-        Navigator.of(context).pushAndRemoveUntil(
-          MaterialPageRoute(
-            builder: (_) => ConfirmationPendingPage(email: email),
-          ),
-          (route) => false,
-        );
+        // Navigate to the confirmation pending screen using go_router to avoid
+        // imperative Navigator calls that conflict with page-based routing.
+        context.go(kConfirmRoute, extra: email);
       }
     });
 

--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -25,7 +25,7 @@ import 'package:app/core/navigation/routes.dart';
 import 'features/action_steps/providers/momentum_listener_provider.dart';
 import 'package:flutter/foundation.dart';
 import 'package:go_router/go_router.dart';
-import 'core/navigation/filtering_route_information_provider.dart';
+import 'package:app/core/navigation/filtering_route_information_provider.dart';
 
 // Global instance to share across app
 final AuthSessionService authSessionService = AuthSessionService();
@@ -295,8 +295,10 @@ class BEEApp extends ConsumerWidget {
       theme: AppTheme.lightTheme,
       darkTheme: AppTheme.darkTheme,
       themeMode: themeMode,
-      routerConfig: appRouter,
       routeInformationProvider: routeInfoProvider,
+      routeInformationParser: appRouter.routeInformationParser,
+      routerDelegate: appRouter.routerDelegate,
+      backButtonDispatcher: appRouter.backButtonDispatcher,
       debugShowCheckedModeBanner: false,
     );
   }

--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -286,7 +286,10 @@ class BEEApp extends ConsumerWidget {
 
     final routeInfoProvider = FilteringRouteInformationProvider(
       PlatformRouteInformationProvider(
-        initialRouteInformation: RouteInformation(uri: Uri.parse('/')),
+        initialRouteInformation: RouteInformation(
+          uri: Uri.parse('/'),
+          state: '/',
+        ),
       ),
     );
 

--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -26,6 +26,7 @@ import 'features/action_steps/providers/momentum_listener_provider.dart';
 import 'package:flutter/foundation.dart';
 import 'package:go_router/go_router.dart';
 import 'package:app/core/navigation/filtering_route_information_provider.dart';
+import 'package:go_router/go_router.dart' as gor;
 
 // Global instance to share across app
 final AuthSessionService authSessionService = AuthSessionService();
@@ -284,11 +285,18 @@ class BEEApp extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final themeMode = ref.watch(themeModeProvider);
 
+    // Provide a minimal state map that matches go_router’s expected schema
+    // {location, state:{codec,json,encoded}}
+    final Map<String, Object?> encodedState = {
+      'location': '/',
+      'state': {'codec': 'json', 'encoded': 'null'},
+    };
+
     final routeInfoProvider = FilteringRouteInformationProvider(
       PlatformRouteInformationProvider(
         initialRouteInformation: RouteInformation(
           uri: Uri.parse('/'),
-          state: <String, Object?>{'location': '/'},
+          state: encodedState,
         ),
       ),
     );

--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -288,7 +288,7 @@ class BEEApp extends ConsumerWidget {
       PlatformRouteInformationProvider(
         initialRouteInformation: RouteInformation(
           uri: Uri.parse('/'),
-          state: '/',
+          state: <String, Object?>{},
         ),
       ),
     );

--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -288,7 +288,7 @@ class BEEApp extends ConsumerWidget {
       PlatformRouteInformationProvider(
         initialRouteInformation: RouteInformation(
           uri: Uri.parse('/'),
-          state: <String, Object?>{},
+          state: <String, Object?>{'location': '/'},
         ),
       ),
     );

--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -11,7 +11,6 @@ import 'core/providers/supabase_provider.dart';
 import 'features/momentum/presentation/screens/momentum_screen.dart';
 import 'features/ai_coach/ui/coach_chat_screen.dart';
 import 'core/utils/deep_link_service.dart';
-import 'package:go_router/go_router.dart';
 import 'features/momentum/presentation/screens/profile_settings_screen.dart';
 import 'features/gamification/ui/rewards_navigator.dart';
 import 'core/notifications/domain/services/notification_preferences_service.dart';
@@ -25,6 +24,8 @@ import 'core/services/auth_session_service.dart';
 import 'package:app/core/navigation/routes.dart';
 import 'features/action_steps/providers/momentum_listener_provider.dart';
 import 'package:flutter/foundation.dart';
+import 'package:go_router/go_router.dart';
+import 'core/navigation/filtering_route_information_provider.dart';
 
 // Global instance to share across app
 final AuthSessionService authSessionService = AuthSessionService();
@@ -283,12 +284,19 @@ class BEEApp extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final themeMode = ref.watch(themeModeProvider);
 
+    final routeInfoProvider = FilteringRouteInformationProvider(
+      PlatformRouteInformationProvider(
+        initialRouteInformation: RouteInformation(uri: Uri.parse('/')),
+      ),
+    );
+
     return MaterialApp.router(
       title: 'BEE Momentum Meter',
       theme: AppTheme.lightTheme,
       darkTheme: AppTheme.darkTheme,
       themeMode: themeMode,
       routerConfig: appRouter,
+      routeInformationProvider: routeInfoProvider,
       debugShowCheckedModeBanner: false,
     );
   }


### PR DESCRIPTION
### What\n1. Replace imperative Navigator call with go_router route (ConfirmationPending).\n2. Add FilteringRouteInformationProvider to ignore custom‐scheme deeplinks that crashed go_router.\n3. Provide minimal encoded initial RouteInformation state to satisfy go_router restoration codec.\n4. Assorted lints clean-up.\n\n### Why\nManual QA was blocked by repeated startup crashes (navigator assertion, codec null checks). These patches stabilise registration launch flow and silent unexpected custom scheme links.\n\n### Test Plan\n• Unit & integration tests pass ().\n• Confirmed iOS device and macOS desktop cold-start succeed with no red screens.\n• Registration ➜ onboarding flow verified.\n\n### Notes\nFollow-up: evaluate long-term deep-link handling once go_router supports custom schemes.\n