### PR TITLE
PES Mini Sprint: spec doc & drop energy_levels migration

### DIFF
--- a/docs/MVP_ROADMAP/1-7 Health Signals/M1.7.1_pes_production_spec.md
+++ b/docs/MVP_ROADMAP/1-7 Health Signals/M1.7.1_pes_production_spec.md
@@ -11,7 +11,7 @@ Ship a complete, user-facing Perceived Energy Score (PES) feature: users can rec
 ## ✅ Success Criteria
 
 - PES check-in UI available from Today Feed and Settings (prompt) – passes WCAG AA.
-- Upsert to `pes_entries` completes < 300 ms p95 (edge > Supabase REST).
+- Upsert to `pes_entries` completes < 300 ms p95 (Flutter ➜ Supabase REST).
 - `update-momentum-score` Edge Function invoked; engagement event logged.
 - Momentum gauge reflects new score < 5 s (realtime channel push).
 - Local notification prompt fires daily at user-selected time; opt-out supported.
@@ -22,7 +22,7 @@ Ship a complete, user-facing Perceived Energy Score (PES) feature: users can rec
 
 | Task ID | Description | Est. Hrs | Status |
 | ------- | ----------- | -------- | ------ |
-| T1 | Delete `energy_levels` code + migrations; write DB migration to drop table | 2h | ⬜ |
+| T1 | Delete `energy_levels` code + migrations; write SQL to drop table | 2h | ⬜ |
 | T2 | Add PES Check-in widget to Today Feed; wire `EnergyInputSlider` → `insertEnergyLevel()` | 4h | ⬜ |
 | T3 | Embed `PesTrendSparkline` into Quick-Stats card | 3h | ⬜ |
 | T4 | Initialise `DailyPromptController` in Settings screen | 2h | ⬜ |
@@ -44,32 +44,32 @@ Ship a complete, user-facing Perceived Energy Score (PES) feature: users can rec
 
 1. **Data**  
    • Table `pes_entries` already exists with RLS.  
-   • Add DB trigger to reject duplicate same-day inserts after 2nd upsert.
+   • Add DB trigger to reject duplicate same-day inserts after second upsert.
 
 2. **Repository**  
-   • Keep `insertEnergyLevel()`; migrate `fetchEnergyLevels()` → `fetchPesEntries()` for consistency.  
+   • Keep `insertEnergyLevel()`; migrate `fetchEnergyLevels()` → `fetchPesEntries()` for naming consistency.  
    • Delete `createEnergyLevel()` & caches tied to `energy_levels`.
 
 3. **UI Integration**  
    • **Today Feed Tile**  
-     - Shows `EnergyInputSlider` when no entry for today.
-     - After save, tile collapses to `PesTrendSparkline` + “Thanks!” toast.  
-   • **Settings › Reminders** – expose prompt time picker using `dailyPromptControllerProvider`.
+     – Shows `EnergyInputSlider` when no entry for today.  
+     – After save, tile collapses to `PesTrendSparkline` + “Thanks!” toast.  
+   • **Settings → Reminders** – expose prompt time picker via `dailyPromptControllerProvider`.
 
 4. **Momentum Wiring**  
    • `update-momentum-score` Edge Function already logs `pes_entry`.  
-   • **Calculator update:** in `supabase/functions/momentum-score-calculator/index.ts` extend `EVENT_WEIGHTS` map with `'pes_entry':10`.
+   • **Calculator update:** in `supabase/functions/momentum-score-calculator/index.ts` extend `EVENT_WEIGHTS` map with `'pes_entry': 10`.
 
 5. **Notifications**  
-   • `NotificationSchedulerService` already abstracts scheduling; call in Settings save handler.
+   • `NotificationSchedulerService` schedules daily prompt; call in Settings save handler.
 
 6. **Deprecation**  
-   • Migration `DROP TABLE IF EXISTS energy_levels CASCADE;`.  
-   • Delete related repository methods, tests, and providers.
+   • SQL migration: `DROP TABLE IF EXISTS energy_levels CASCADE;`.  
+   • Delete related repository methods, providers, and tests.
 
 7. **Testing**  
-   • Widget test: select emoji → provider state updated; confirm DB call mocked.  
-   • Playwright e2e: simulate user flow through Today Feed, assert Websocket momentum update.
+   • Widget test: select emoji → provider state updated; DB call mocked.  
+   • Playwright e2e: simulate Today Feed check-in, assert websocket momentum update.
 
 ### Rate-Limiting (No change)
 PES insert frequency naturally capped at 1 per user/day by UNIQUE(user_id,date).
@@ -86,6 +86,4 @@ PES insert frequency naturally capped at 1 per user/day by UNIQUE(user_id,date).
 
 - Supabase secrets from `~/.bee_secrets/supabase.env` (CI, local dev).
 - Relies on Momentum Score listener (Epic 1.8) for realtime channel push.
-- Requires Today Feed refactor PR (#T2.2) to allow inserting new card.
-
---- 
+- Requires Today Feed refactor PR (#T2.2) to allow inserting new card. 

--- a/docs/MVP_ROADMAP/1-7 Health Signals/M1.7.1_pes_production_spec.md
+++ b/docs/MVP_ROADMAP/1-7 Health Signals/M1.7.1_pes_production_spec.md
@@ -22,7 +22,7 @@ Ship a complete, user-facing Perceived Energy Score (PES) feature: users can rec
 
 | Task ID | Description | Est. Hrs | Status |
 | ------- | ----------- | -------- | ------ |
-| T1 | Delete `energy_levels` code + migrations; write SQL to drop table | 2h | ⬜ |
+| T1 | Delete `energy_levels` code + migrations; write SQL to drop table | 2h | ✅ Completed |
 | T2 | Add PES Check-in widget to Today Feed; wire `EnergyInputSlider` → `insertEnergyLevel()` | 4h | ⬜ |
 | T3 | Embed `PesTrendSparkline` into Quick-Stats card | 3h | ⬜ |
 | T4 | Initialise `DailyPromptController` in Settings screen | 2h | ⬜ |

--- a/supabase/migrations/20250722210000_drop_energy_levels.sql
+++ b/supabase/migrations/20250722210000_drop_energy_levels.sql
@@ -5,4 +5,4 @@
 set check_function_bodies = off;
 
 -- Drop table and cascade to associated policies, triggers, etc.
-drop table if exists public.energy_levels cascade; 
+drop table if exists public.energy_levels cascade;

--- a/supabase/migrations/20250722210000_drop_energy_levels.sql
+++ b/supabase/migrations/20250722210000_drop_energy_levels.sql
@@ -1,0 +1,8 @@
+-- Migration: Drop deprecated energy_levels table (PES rollout)
+-- Description: Removes legacy energy_levels table and associated objects.
+-- Generated at 2025-07-22 21:00 UTC
+
+set check_function_bodies = off;
+
+-- Drop table and cascade to associated policies, triggers, etc.
+drop table if exists public.energy_levels cascade; 


### PR DESCRIPTION
This PR adds the PES mini-sprint production rollout specification (docs) and removes the legacy energy_levels table via a new Supabase migration.\n\nKey points:\n• Adds docs/MVP_ROADMAP/1-7 Health Signals/M1.7.1_pes_production_spec.md\n• Adds migration supabase/migrations/20250722210000_drop_energy_levels.sql\n• sqlfluff passes on new migration; legacy files ignored via CI continue-on-error.\n\nPart of Epic 1.7 Health Signals.\n