### PR TITLE
Embed PesTrendSparkline into Quick-Stats card (Task T3)

### DIFF
--- a/app/lib/features/momentum/presentation/widgets/components/individual_stat_card.dart
+++ b/app/lib/features/momentum/presentation/widgets/components/individual_stat_card.dart
@@ -11,6 +11,7 @@ class IndividualStatCard extends StatefulWidget {
   final String label;
   final Color color;
   final VoidCallback? onTap;
+  final Widget? valueWidget;
 
   const IndividualStatCard({
     super.key,
@@ -19,6 +20,7 @@ class IndividualStatCard extends StatefulWidget {
     required this.label,
     required this.color,
     this.onTap,
+    this.valueWidget,
   });
 
   @override
@@ -117,17 +119,19 @@ class _IndividualStatCardState extends State<IndividualStatCard>
                               0.1,
                         ),
                         Flexible(
-                          child: Text(
-                            widget.value,
-                            style: Theme.of(
-                              context,
-                            ).textTheme.titleSmall?.copyWith(
-                              color: widget.color,
-                              fontWeight: FontWeight.w600,
-                            ),
-                            maxLines: 1,
-                            overflow: TextOverflow.ellipsis,
-                          ),
+                          child:
+                              widget.valueWidget ??
+                              Text(
+                                widget.value,
+                                style: Theme.of(
+                                  context,
+                                ).textTheme.titleSmall?.copyWith(
+                                  color: widget.color,
+                                  fontWeight: FontWeight.w600,
+                                ),
+                                maxLines: 1,
+                                overflow: TextOverflow.ellipsis,
+                              ),
                         ),
                         SizedBox(
                           height:

--- a/app/lib/features/momentum/presentation/widgets/components/stats_cards_layout.dart
+++ b/app/lib/features/momentum/presentation/widgets/components/stats_cards_layout.dart
@@ -5,6 +5,7 @@ import '../../../../../core/services/responsive_service.dart';
 import '../../../domain/models/momentum_data.dart';
 import '../../../../action_steps/data/action_step_repository.dart';
 import 'individual_stat_card.dart';
+import '../../../../health_signals/pes/widgets/pes_trend_sparkline.dart';
 
 /// Layout handler for stats cards supporting standard and compact layouts
 /// Responsive design with proper spacing and accessibility
@@ -74,11 +75,12 @@ class StatsCardsLayout extends StatelessWidget {
 
   IndividualStatCard _buildReadinessCard() {
     return IndividualStatCard(
-      icon: Icons.self_improvement_rounded,
-      value: '--', // Placeholder until DNS logic is wired
-      label: 'Readiness',
+      icon: Icons.bolt_rounded,
+      value: '',
+      valueWidget: const PesTrendSparkline(),
+      label: 'Energy',
       color: AppTheme.momentumSteady,
-      onTap: onLessonsTap, // Reuse callback slot for future DNS survey
+      onTap: onLessonsTap, // Preserve accessibility semantics
     );
   }
 

--- a/docs/MVP_ROADMAP/1-7 Health Signals/M1.7.1_pes_production_spec.md
+++ b/docs/MVP_ROADMAP/1-7 Health Signals/M1.7.1_pes_production_spec.md
@@ -24,7 +24,7 @@ Ship a complete, user-facing Perceived Energy Score (PES) feature: users can rec
 | ------- | ----------- | -------- | ------ |
 | T1 | Delete `energy_levels` code + migrations; write SQL to drop table | 2h | ✅ |
 | T2 | Add PES Check-in widget to Today Feed; wire `EnergyInputSlider` → `insertEnergyLevel()` | 4h | ✅ |
-| T3 | Embed `PesTrendSparkline` into Quick-Stats card | 3h | ⬜ |
+| T3 | Embed `PesTrendSparkline` into Quick-Stats card | 3h | ✅ |
 | T4 | Initialise `DailyPromptController` in Settings screen | 2h | ⬜ |
 | T5 | Update Momentum Calculator: weight map for `pes_entry` (+10) | 3h | ⬜ |
 | T6 | Remove stale `energy_levels` provider/tests; migrate trend provider to `pes_entries` | 3h | ⬜ |


### PR DESCRIPTION
Completes Task T3 of PES Mini Sprint: embed sparkline in Momentum Quick-Stats card, refactor IndividualStatCard, update docs, tests pass.