### PR TITLE
feat(health-signals): add pes_entry weight to momentum calculator (Task T5)

### DIFF
--- a/docs/MVP_ROADMAP/1-7 Health Signals/M1.7.1_pes_production_spec.md
+++ b/docs/MVP_ROADMAP/1-7 Health Signals/M1.7.1_pes_production_spec.md
@@ -26,7 +26,7 @@ Ship a complete, user-facing Perceived Energy Score (PES) feature: users can rec
 | T2 | Add PES Check-in widget to Today Feed; wire `EnergyInputSlider` → `insertEnergyLevel()` | 4h | ✅ |
 | T3 | Embed `PesTrendSparkline` into Quick-Stats card | 3h | ✅ |
 | T4 | Initialise `DailyPromptController` in Settings screen | 2h | ✅ |
-| T5 | Update Momentum Calculator: weight map for `pes_entry` (+10) | 3h | ⬜ |
+| T5 | Update Momentum Calculator: weight map for `pes_entry` (+10) | 3h | ✅ |
 | T6 | Remove stale `energy_levels` provider/tests; migrate trend provider to `pes_entries` | 3h | ⬜ |
 | T7 | Add e2e Playwright test: slider → DB row → momentum update websocket | 4h | ⬜ |
 | T8 | Documentation & release notes | 1h | ⬜ |

--- a/supabase/functions/momentum-score-calculator/index.ts
+++ b/supabase/functions/momentum-score-calculator/index.ts
@@ -70,6 +70,7 @@ const MOMENTUM_CONFIG = {
     'resource_access': 5,
     'peer_interaction': 8,
     'reminder_response': 7,
+    'pes_entry': 10,
   },
 
   // Maximum daily score caps


### PR DESCRIPTION
### Summary\nAdds 'pes_entry': 10 to EVENT_WEIGHTS in the momentum-score-calculator edge function.\n\nCompletes Task T5 in M1.7.1 PES Production Roll-Out specification.\n\n### Notes\n- Updated spec doc to mark Task T5 complete.\n- All tests and linters pass via pre-commit hooks.\n