### PR TITLE
docs: add M1.8.1 Schema & Signal Foundations spec

### DIFF
--- a/docs/MVP_ROADMAP/1-8 Momentum-Motivation Score/M1.8.1_schema_signal_foundations.md
+++ b/docs/MVP_ROADMAP/1-8 Momentum-Motivation Score/M1.8.1_schema_signal_foundations.md
@@ -1,0 +1,100 @@
+### M1.8.1 · Schema & Signal Foundations
+**Epic:** 1.8 Momentum & Motivation Scores  
+**Status:** 🟡 Planned  
+
+---
+
+## Goal
+Establish the foundational database schema and data-flow groundwork required for Momentum & Motivation scoring. This milestone creates the core tables, views, and back-fill utilities that later calculators will rely on.
+
+## Success Criteria
+- All new tables created with primary/foreign keys and auditing columns.
+- `daily_momentum_scores` view returns same columns as legacy consumers.
+- pgTAP tests assert PK/FK, NOT NULL & uniqueness constraints.
+- Migrations are reversible; rollback succeeds without data loss.
+- Back-fill job inserts momentum rows for 100 % of active users with ≤1 % error rate.
+
+## Milestone Breakdown
+| Task ID | Description | Est. Hrs | Status |
+| ------- | ----------- | -------- | ------ |
+| T1 | Create `momentum_events`, `momentum_pillars` tables as per implementation guide | 3h | 🟡 |
+| T2 | Add `motivation_journal`, `habit_index` tables | 3h | 🟡 |
+| T3 | Migrate legacy `daily_engagement_scores` → view `daily_momentum_scores` | 2h | 🟡 |
+| T4 | Data back-fill job for empty-day momentum rows | 2h | 🟡 |
+
+## Milestone Deliverables
+- SQL migration files defining four new tables plus view.
+- pgTAP test suite validating schema constraints.
+- Python (or Deno) script `scripts/backfill_momentum_rows.py` runnable with Supabase service-role key.
+- Updated ERD diagram link in docs.
+- PR description containing sample query outputs.
+
+## Implementation Details
+### 1. Database Migrations
+- Place migration SQL in `supabase/migrations/<timestamp>_momentum_schema.sql` following Supabase CLI naming.
+- Use `created_at`, `updated_at` TIMESTAMPTZ columns + `deleted_at` soft-delete.
+- Enforce RLS; initially disabled (`ALTER TABLE ... ENABLE ROW LEVEL SECURITY;`) but policies added in later milestones.
+
+```sql
+-- momentum_events
+CREATE TABLE IF NOT EXISTS momentum_events (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID REFERENCES auth.users(id) ON DELETE CASCADE,
+  event_type TEXT NOT NULL,
+  event_ts TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  payload JSONB,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+```
+_Similar DDL for other tables; include FK to `momentum_pillars.id` where relevant._
+
+- Create view:
+```sql
+CREATE OR REPLACE VIEW daily_momentum_scores AS
+SELECT user_id,
+       score,
+       score_ts::DATE AS score_date,
+       pillar_breakdown
+FROM legacy.daily_engagement_scores; -- maintains backward-compat
+```
+
+### 2. pgTAP Tests
+- Store under `supabase/migrations/tests/`.
+- Assertions: primary keys exist, FKs valid, indexes on `user_id`, uniqueness on `user_id, score_date`.
+- Ensure view columns & types match legacy expectation.
+
+### 3. Back-fill Utility
+- `scripts/backfill_momentum_rows.py`
+  • Connect using `$SUPABASE_SERVICE_ROLE_KEY` from `~/.bee_secrets/supabase.env`.
+  • For each active user lacking a row on a given day, insert default momentum row (`score = 0`).
+  • Batch in pages of 500, commit every 1000 rows to avoid locks.
+  • Dry-run flag `--dry-run` prints counts only.
+
+### 4. Testing Approach
+- Unit tests: pgTAP for DDL; pytest for back-fill script using test Postgres container (`scripts/start_test_db.sh`).
+- CI: hook into `make ci-fast` matrix; ensure coverage delta ≥ +1 %.
+
+### 5. Edge Cases & Performance
+- High-volume inserts: use `INSERT ... ON CONFLICT DO NOTHING`.
+- Legacy score discrepancies: flag mismatches >5 pts in log for manual review.
+- Time-zone normalization: use UTC across schema.
+
+### 6. Architectural References
+- Follows `auto_flutter_architecture` DB standards.
+- File sizes: each migration <300 LOC; split if longer per component governance.
+
+## Acceptance Criteria
+- [ ] Supabase migration deploys cleanly on staging.
+- [ ] All pgTAP tests pass (`make ci-fast`).
+- [ ] View consumers run without code changes.
+- [ ] Back-fill inserts rows for fixture dataset with zero errors.
+- [ ] Documentation updated and reviewed by stakeholders.
+
+## Dependencies / Notes
+- Engagement events logging pipeline must already populate source events.
+- Requires Supabase CLI configured and env file at `~/.bee_secrets/supabase.env`.
+- Downstream calculator functions depend on these tables; avoid breaking changes once merged.
+
+---
+
+🟡 Planned 🔵 In Progress ✅ Complete 


### PR DESCRIPTION
Adds detailed technical specification for Milestone M1.8.1 under Epic 1.8, including schema migrations, pgTAP tests, and backfill utility.