### PR TITLE
epic 1 8/T2 event weights v2

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -132,3 +132,5 @@ fee3ec5a8d0b1bba1e8cd16370d3d89427423b62:supabase_test.js:jwt:1
 fee3ec5a8d0b1bba1e8cd16370d3d89427423b62:supabase_test.js:real-supabase-anon-key:1
 3eaef63370355e9d10ef3dad8f9a5bc4619bfd6a:gitleaks_test.js:stripe-access-token:1
 f59a1018bb8b00b52235b7dd17729d8827be7cf7:run_dev.sh:flutter-dart-define-secrets:67
+30bbbc14fc207badbb1b15ad2d73de4f3439b5e2:supabase/functions/momentum-score-calculator/v2/deno.lock:generic-api-key:117
+f5ef989833da84a8aca25f74b518be60a1b40fa2:supabase/functions/momentum-score-calculator/v2/deno.lock:generic-api-key:117

--- a/docs/MVP_ROADMAP/1-8 Momentum-Motivation Score/Milestones, Tasks, and Epic Docs/M1.8.2_momentum_score_calculator_v2.md
+++ b/docs/MVP_ROADMAP/1-8 Momentum-Motivation Score/Milestones, Tasks, and Epic Docs/M1.8.2_momentum_score_calculator_v2.md
@@ -17,8 +17,8 @@ Enhance the existing momentum-scoring pipeline so it (a) incorporates updated ev
 ## Milestone Breakdown
 | Task ID | Description | Est. Hrs | Status |
 | ------- | ----------- | -------- | ------ |
-| T1 | Refactor edge function `momentum-score-calculator` to **v2** SemVer tag | 4h | 🟡 |
-| T2 | Add new **event_weights_v2.json** + cap logic | 2h | 🟡 |
+| T1 | Refactor edge function `momentum-score-calculator` to **v2** SemVer tag | 4h | ✅ |
+| T2 | Add new **event_weights_v2.json** + cap logic | 2h | ✅ |
 | T3 | Emit explicit daily rows when no events occur | 2h | 🟡 |
 | T4 | Unit tests (>5 messages, zero-event day, new signals) | 4h | 🟡 |
 | T5 | Deploy daily momentum **back-fill** cron job | 1h | 🟡 |

--- a/supabase/functions/momentum-score-calculator/v2/event_weights_v2.json
+++ b/supabase/functions/momentum-score-calculator/v2/event_weights_v2.json
@@ -1,0 +1,6 @@
+{
+  "chat_message": 2,
+  "biometric_sync": 1,
+  "action_step_complete": 3,
+  "max_weight_per_day": 10
+} 

--- a/supabase/functions/momentum-score-calculator/v2/index.ts
+++ b/supabase/functions/momentum-score-calculator/v2/index.ts
@@ -797,21 +797,25 @@ try {
   const weightsUrl = new URL('./event_weights_v2.json', import.meta.url)
   const raw = Deno.readTextFileSync(weightsUrl)
   const weightsData = JSON.parse(raw) as Record<string, number> & { max_weight_per_day: number }
-  const { max_weight_per_day, ...eventWeights } = weightsData
-  // Cast to any to satisfy structural typing without enumerating keys
+  const { max_weight_per_day, ...eventWeights } = weightsData // Cast to any to satisfy structural typing without enumerating keys
   // deno-lint-ignore no-explicit-any
-  ;(MOMENTUM_CONFIG.EVENT_WEIGHTS as unknown as any) = eventWeights
-  // deno-lint-ignore no-explicit-any
+  ;(MOMENTUM_CONFIG.EVENT_WEIGHTS as unknown as any) = eventWeights // deno-lint-ignore no-explicit-any
   ;(MOMENTUM_CONFIG.MAX_DAILY_SCORE as unknown as any) = max_weight_per_day
 } catch (err) {
   console.warn('[MomentumScoreCalculator] Using default EVENT_WEIGHTS; failed to load JSON:', err)
 }
 
-// Main handler
-serve(async (request: Request) => {
+// -----------------------------------------------------------------------------
+// Exported handler (for tests) and runtime serve()
+// -----------------------------------------------------------------------------
+
+export async function handleRequest(request: Request): Promise<Response> {
   const client = await getSupabaseClient() as unknown as DBSupabaseClientLite
   const errorHandler = new MomentumErrorHandler(client)
 
   const calculator = new MomentumScoreCalculator(client, errorHandler)
   return await calculator.handleRequest(request)
-})
+}
+
+// Deploy-time entrypoint
+serve(handleRequest)

--- a/supabase/functions/momentum-score-calculator/v2/index.ts
+++ b/supabase/functions/momentum-score-calculator/v2/index.ts
@@ -798,7 +798,7 @@ try {
   const raw = Deno.readTextFileSync(weightsUrl)
   const weightsData = JSON.parse(raw) as Record<string, number> & { max_weight_per_day: number }
   const { max_weight_per_day, ...eventWeights } = weightsData // Cast to any to satisfy structural typing without enumerating keys
-  // deno-lint-ignore no-explicit-any
+   // deno-lint-ignore no-explicit-any
   ;(MOMENTUM_CONFIG.EVENT_WEIGHTS as unknown as any) = eventWeights // deno-lint-ignore no-explicit-any
   ;(MOMENTUM_CONFIG.MAX_DAILY_SCORE as unknown as any) = max_weight_per_day
 } catch (err) {

--- a/supabase/functions/momentum-score-calculator/v2/momentum_calculator.test.ts
+++ b/supabase/functions/momentum-score-calculator/v2/momentum_calculator.test.ts
@@ -1,0 +1,60 @@
+// deno-lint-ignore-file no-explicit-any
+import { assertEquals } from 'https://deno.land/std@0.208.0/assert/mod.ts'
+import { MomentumErrorHandler } from './error-handler.ts'
+import * as mod from './index.ts'
+
+// -----------------------------------------------------------------------------
+// Environment
+// -----------------------------------------------------------------------------
+Deno.env.set('DENO_TESTING', 'true')
+Deno.env.set('SUPABASE_SERVICE_ROLE_KEY', 'test-service-key')
+Deno.env.set('SUPABASE_URL', 'http://localhost:54321')
+
+// -----------------------------------------------------------------------------
+// Helpers
+// -----------------------------------------------------------------------------
+const stubQueryBuilder = {
+  select: () => Promise.resolve({ data: null, error: null }),
+  insert: () => Promise.resolve({ data: null, error: null }),
+  upsert: () => Promise.resolve({ data: null, error: null }),
+  eq: () => stubQueryBuilder,
+  gte: () => stubQueryBuilder,
+  lt: () => stubQueryBuilder,
+  order: () => stubQueryBuilder,
+  single: () => Promise.resolve({ data: null, error: null }),
+}
+
+const stubClient = {
+  from: () => stubQueryBuilder,
+  rpc: () => Promise.resolve({ data: null, error: null }),
+} as unknown as any
+
+// -----------------------------------------------------------------------------
+// Tests
+// -----------------------------------------------------------------------------
+Deno.test('MOMENTUM_CONFIG loads weights & daily cap from JSON', () => {
+  const CONFIG = (mod as any).MOMENTUM_CONFIG
+  assertEquals(CONFIG.MAX_DAILY_SCORE, 10)
+  assertEquals(CONFIG.EVENT_WEIGHTS.chat_message, 2)
+  assertEquals(CONFIG.EVENT_WEIGHTS.biometric_sync, 1)
+})
+
+Deno.test('calculateRawScore respects max_weight_per_day cap', () => {
+  const Calculator = (mod as any).MomentumScoreCalculator
+  const errorHandler = new MomentumErrorHandler(stubClient)
+  const calc = new Calculator(stubClient, errorHandler)
+
+  // Create 20 events of the same type (weight 3 each)
+  const events = Array.from({ length: 20 }).map((_, idx) => ({
+    id: `${idx}`,
+    user_id: 'test-user',
+    event_type: 'action_step_complete',
+    event_date: '2025-01-01',
+    event_timestamp: new Date().toISOString(),
+    metadata: {},
+    points_awarded: 0,
+  }))
+
+  const raw = (calc as any).calculateRawScore(events)
+  assertEquals(raw, 10)
+}) 

--- a/supabase/functions/momentum-score-calculator/v2/momentum_calculator.test.ts
+++ b/supabase/functions/momentum-score-calculator/v2/momentum_calculator.test.ts
@@ -57,4 +57,4 @@ Deno.test('calculateRawScore respects max_weight_per_day cap', () => {
 
   const raw = (calc as any).calculateRawScore(events)
   assertEquals(raw, 10)
-}) 
+})


### PR DESCRIPTION
- **feat(momentum-score-calculator): add event_weights_v2.json and load dynamic weights with per-day cap**
- **test(momentum-score-calculator): add unit tests for JSON weights loading and daily cap**
- **chore(security): ignore generic API hash in momentum-score deno.lock false positives**
- **chore(momentum-score-calculator): minor comment tweaks and ensure .gitleaksignore tracked**
